### PR TITLE
refactor: 将 `YumeSignEnum` 移动到 `constants/` 目录 & 更新导入

### DIFF
--- a/src/constants/YumeSignEnum.ts
+++ b/src/constants/YumeSignEnum.ts
@@ -1,7 +1,7 @@
 // SIGN for AUTO_BEHAVIOR
 import { SimulatedPlayer, LookDuration } from '@minecraft/server-gametest'
 import { Player } from '@minecraft/server'
-import { commandManager } from '../../command'
+import { commandManager } from '../command'
 import { ModalFormData } from '@minecraft/server-ui';
 
 export  enum  SIGN {

--- a/src/plugins/breakBlock.ts
+++ b/src/plugins/breakBlock.ts
@@ -8,7 +8,7 @@ import {
 import { Command, commandManager } from '../command';
 import { getSimPlayer } from '../utils/Util'
 import { world, system } from "@minecraft/server"
-import SIGN from "../lib/xboyPackage/YumeSignEnum";
+import SIGN from "../constants/YumeSignEnum";
 
 const breakBlockCommand = new Command();
 breakBlockCommand.register(({ args }) => args.length === 0, ({ entity, isEntity }) => {

--- a/src/plugins/command.ts
+++ b/src/plugins/command.ts
@@ -21,7 +21,7 @@ import type { World } from '../@types/globalThis'
 
 // import qrcode from "../../lib/qrcode-terminal/mod.js";
 
-import SIGN, { exeBehavior } from "../lib/xboyPackage/YumeSignEnum";
+import SIGN, { exeBehavior } from "../constants/YumeSignEnum";
 import {getSimPlayer} from "../utils/Util";
 //
 // import {BlockLocation} from "../../@types/globalThis";

--- a/src/plugins/gui.ts
+++ b/src/plugins/gui.ts
@@ -6,7 +6,7 @@ import SIGN, {
     exeBehavior,
     SIGN_TAG_LIST,
     SIGN_ZH
-} from '../lib/xboyPackage/YumeSignEnum'
+} from '../constants/YumeSignEnum'
 import { ActionFormData } from '@minecraft/server-ui'
 import { SimulatedPlayer } from '@minecraft/server-gametest'
 import { getSimPlayer } from '../utils/Util'

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -12,7 +12,7 @@ import { register } from '@minecraft/server-gametest'
 import { PIDManager } from '../core/pid'
 import EventSignal from '../lib/xboyEvents/EventSignal'
 
-import { SIGN } from '../lib/xboyPackage/YumeSignEnum'
+import { SIGN } from '../constants/YumeSignEnum'
 import { world } from '@minecraft/server'
 
 // import './plugins/noFlashDoor' // pig

--- a/src/plugins/task.ts
+++ b/src/plugins/task.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck
 import type { SimulatedPlayer } from '@minecraft/server-gametest'
 import {simulatedPlayers, testWorldLocation} from './main'
-import SIGN from '../lib/xboyPackage/YumeSignEnum'
+import SIGN from '../constants/YumeSignEnum'
 import type { EntityHealthComponent, Vector3 } from '@minecraft/server'
 import { system, world } from '@minecraft/server'
 import { getEntitiesNear, getPlayerNear } from '../utils/Util'

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -1,6 +1,6 @@
 import type {Block, Dimension, Entity, EntityQueryOptions, Player, Vector3} from '@minecraft/server'
 import {SimulatedPlayer} from '@minecraft/server-gametest'
-import SIGN from '../lib/xboyPackage/YumeSignEnum'
+import SIGN from '../constants/YumeSignEnum'
 
 
 // getEntitiesFromViewDirection


### PR DESCRIPTION
- 将 `YumeSignEnum.ts` 从 `lib/xboyPackage` 目录移动到 `constants/` 目录
- 同步更新相关文件中的导入路径
- 计划将常量定义放在统一位置