### PR TITLE
refactor: 新增 simulated-player 模块 统一管理模拟玩家相关的增删查

### DIFF
--- a/src/core/simulated-player/errors.ts
+++ b/src/core/simulated-player/errors.ts
@@ -1,0 +1,13 @@
+export class UninitializedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UninitializedError";
+    }
+}
+
+export class SimulatedPlayerNotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "SimulatedPlayerNotFoundError";
+    }
+}

--- a/src/core/simulated-player/errors.ts
+++ b/src/core/simulated-player/errors.ts
@@ -1,4 +1,4 @@
-export class UninitializedError extends Error {
+export class NotReadyError extends Error {
     constructor(message: string) {
         super(message);
         this.name = "UninitializedError";

--- a/src/core/simulated-player/errors.ts
+++ b/src/core/simulated-player/errors.ts
@@ -1,7 +1,7 @@
 export class NotReadyError extends Error {
     constructor(message: string) {
         super(message);
-        this.name = "UninitializedError";
+        this.name = "NotReadyError";
     }
 }
 

--- a/src/core/simulated-player/index.ts
+++ b/src/core/simulated-player/index.ts
@@ -1,0 +1,3 @@
+export * from './manager';
+export * from './errors';
+export type * from './types';

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -33,7 +33,7 @@ export class SimulatedPlayerManager {
         system.run(() => {
             try {
                 overworld.runCommand(`execute positioned 15000000 256 ${z} run gametest run 我是云梦:假人`);
-                this._initialized= true;
+                this._initialized = true;
             } catch (e) {
                 world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);
             }
@@ -41,7 +41,7 @@ export class SimulatedPlayerManager {
     }
 
     get ready(): boolean {
-        return this._initialized && Boolean(this._test)
+        return this._initialized && Boolean(this._test);
     }
 
     get simulatedPlayers(): Map<PID, SimulatedPlayer> {
@@ -78,8 +78,6 @@ export class SimulatedPlayerManager {
     }
 
     add({ name, location, dimension }: AddSimulatedPlayerOptions) {
-        console.log(this._initialized,this._test);
-        
         if (!this.ready)
             throw new UninitializedError('call initialize() first');//改名
 

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -25,14 +25,24 @@ export class SimulatedPlayerManager {
         this._test = test;
     }
 
+    private generateTestPosition(): Vector3 {
+        const z = 11451400 + Math.floor(Math.random() * 114514 * 19);
+        return {
+            x: 15000000,
+            y: 256,
+            z
+        };
+    }
+
     initialize() {//test 独立出单独方法？
         // 记分板PID初始化
         this.pidManager.initialize();
 
-        const z = 11451400 + Math.floor(Math.random() * 114514 * 19);
+        const { x, y, z } = this.generateTestPosition();
+
         system.run(() => {
             try {
-                overworld.runCommand(`execute positioned 15000000 256 ${z} run gametest run 我是云梦:假人`);
+                overworld.runCommand(`execute positioned ${x} ${y} ${z} run gametest run 我是云梦:假人`);
                 this._initialized = true;
             } catch (e) {
                 world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -104,6 +104,18 @@ export class SimulatedPlayerManager {
         }
     }
 
+    has(pid: PID): boolean;
+    has(id: string): boolean;
+    has(simulatedPlayer: SimulatedPlayer): boolean;
+    has(target: PID | string | SimulatedPlayer): boolean {
+        if (typeof target === 'number')
+            return this._pidToSimulatedPlayer.has(target);
+        else if (typeof target === 'string')
+            return this._idToPid.has(target);
+
+        return this._idToPid.has(target.id);
+    }
+
     getPID(id: string): PID | undefined {
         return this._idToPid.get(id);
     }

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -1,4 +1,4 @@
-import { LocationOutOfWorldBoundariesError, system, world, type Dimension, type Entity, type Vector3 } from "@minecraft/server";
+import { system, world, type Dimension, type Entity, type Vector3 } from "@minecraft/server";
 import { PIDManager, type PID } from "../pid";
 import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
 import SIGN from "../../constants/YumeSignEnum";
@@ -66,12 +66,8 @@ export class SimulatedPlayerManager {
             //@ts-ignore
             simulatedPlayer.teleport(location, { dimension });
         } catch (e) {
-            if (e instanceof LocationOutOfWorldBoundariesError) {
-                console.warn('[模拟玩家] 有东西尝试在非法位置生成假人，已阻止');
-                simulatedPlayer.disconnect();
-            } else {
-                throw e;
-            }
+            simulatedPlayer.disconnect();
+            throw e;
         }
 
         return simulatedPlayer;

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -1,0 +1,133 @@
+import { LocationOutOfWorldBoundariesError, system, world, type Dimension, type Vector3 } from "@minecraft/server";
+import { PIDManager, type PID } from "../pid";
+import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
+import SIGN from "../../constants/YumeSignEnum";
+import { SimulatedPlayerNotFoundError, UninitializedError } from "./errors";
+import type { AddSimulatedPlayerOptions } from "./types";
+
+const overworld = world.getDimension('overworld');
+
+export class SimulatedPlayerManager {
+    private readonly initialSigns = [
+        SIGN.YUME_SIM_SIGN,
+        SIGN.AUTO_RESPAWN_SIGN
+    ] as const;
+
+    private _test: Test | null = null;
+    private _initialized = false;
+
+    private _pidToSimulatedPlayer = new Map<PID, SimulatedPlayer>();
+    private _idToPid = new Map<string, PID>();
+
+    constructor(public readonly pidManager: PIDManager = new PIDManager()) {}
+
+    set test(test: Test) {
+        this._test = test;
+    }
+
+    initialize() {//test 独立出单独方法？
+        // 记分板PID初始化
+        this.pidManager.initialize();
+
+        const z = 11451400 + Math.floor(Math.random() * 114514 * 19);
+        system.run(() => {
+            try {
+                overworld.runCommand(`execute positioned 15000000 256 ${z} run gametest run 我是云梦:假人`);
+                this._initialized= true;
+            } catch (e) {
+                world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);
+            }
+        });
+    }
+
+    get ready(): boolean {
+        return this._initialized && Boolean(this._test)
+    }
+
+    get simulatedPlayers(): Map<PID, SimulatedPlayer> {
+        return this._pidToSimulatedPlayer;
+    }
+
+    get simulatedPlayerIdToPidMap(): Map<string, PID> {
+        return this._idToPid;
+    }
+
+    private generateName(pid: PID) {
+        return `工具人-${pid}`;
+    }
+
+    private spawn(location: Vector3, dimension: Dimension, name: string): SimulatedPlayer {
+        const simulatedPlayer = this._test!.spawnSimulatedPlayer({ x: 0, y: 8, z: 0 }, name);
+        simulatedPlayer.addTag('init');
+        this.initialSigns.forEach(sign => simulatedPlayer.addTag(sign));
+        try {
+            //@ts-ignore
+            simulatedPlayer.setSpawnPoint({ ...location, dimension });
+            //@ts-ignore
+            simulatedPlayer.teleport(location, { dimension });
+        } catch (e) {
+            if (e instanceof LocationOutOfWorldBoundariesError) {
+                console.warn('[模拟玩家] 有东西尝试在非法位置生成假人，已阻止');
+                simulatedPlayer.disconnect();
+            } else {
+                throw e;
+            }
+        }
+
+        return simulatedPlayer;
+    }
+
+    add({ name, location, dimension }: AddSimulatedPlayerOptions) {
+        console.log(this._initialized,this._test);
+        
+        if (!this.ready)
+            throw new UninitializedError('call initialize() first');//改名
+
+        const pid = this.pidManager.next();
+        name ??= this.generateName(pid);
+
+        const simulatedPlayer = this.spawn(location, dimension, name);
+
+        this._pidToSimulatedPlayer.set(pid, simulatedPlayer);
+        this._idToPid.set(simulatedPlayer.id, pid);
+    }
+
+    get(pid: PID): SimulatedPlayer | undefined;
+    get(id: string): SimulatedPlayer | undefined;
+    get(idOrPID: PID | string): SimulatedPlayer | undefined {
+        if (typeof idOrPID === 'number') {
+            return this._pidToSimulatedPlayer.get(idOrPID);
+        } else {
+            const pid = this.getPID(idOrPID);
+            if (pid === undefined) return undefined;
+            return this._pidToSimulatedPlayer.get(pid);
+        }
+    }
+
+    getPID(id: string): PID | undefined {
+        return this._idToPid.get(id);
+    }
+
+    remove(pid: PID): void;
+    remove(simulatedPlayer: SimulatedPlayer): void;
+    remove(pidOrSimulatedPlayer: PID | SimulatedPlayer): void {
+        let pid: PID | undefined;
+        let simulatedPlayer: SimulatedPlayer | undefined;
+
+        if (typeof pidOrSimulatedPlayer === 'number') {
+            pid = pidOrSimulatedPlayer;
+            simulatedPlayer = this.get(pidOrSimulatedPlayer);
+        } else {
+            simulatedPlayer = pidOrSimulatedPlayer;
+            pid = this.getPID(simulatedPlayer.id);
+        }
+
+        if (!simulatedPlayer || !pid)
+            throw new SimulatedPlayerNotFoundError('SimulatedPlayer not found');
+
+        simulatedPlayer.disconnect();
+
+        this._idToPid.delete(simulatedPlayer.id);
+        this._pidToSimulatedPlayer.delete(pid);
+    }
+}

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -19,7 +19,7 @@ export class SimulatedPlayerManager {
     private _pidToSimulatedPlayer = new Map<PID, SimulatedPlayer>();
     private _idToPid = new Map<string, PID>();
 
-    constructor(public readonly pidManager: PIDManager = new PIDManager()) {}
+    constructor(private readonly pidManager: PIDManager = new PIDManager()) {}
 
     set test(test: Test) {
         this._test = test;
@@ -145,5 +145,9 @@ export class SimulatedPlayerManager {
 
         this._idToPid.delete(simulatedPlayer.id);
         this._pidToSimulatedPlayer.delete(pid);
+    }
+
+    resetPID(): PID {
+        return this.pidManager.reset();
     }
 }

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -1,4 +1,4 @@
-import { LocationOutOfWorldBoundariesError, system, world, type Dimension, type Vector3 } from "@minecraft/server";
+import { LocationOutOfWorldBoundariesError, system, world, type Dimension, type Entity, type Vector3 } from "@minecraft/server";
 import { PIDManager, type PID } from "../pid";
 import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
 import SIGN from "../../constants/YumeSignEnum";
@@ -104,8 +104,8 @@ export class SimulatedPlayerManager {
 
     has(pid: PID): boolean;
     has(id: string): boolean;
-    has(simulatedPlayer: SimulatedPlayer): boolean;
-    has(target: PID | string | SimulatedPlayer): boolean {
+    has(simulatedPlayer: Entity): boolean;
+    has(target: PID | string | Entity): boolean {
         if (typeof target === 'number')
             return this._pidToSimulatedPlayer.has(target);
         else if (typeof target === 'string')

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -60,7 +60,6 @@ export class SimulatedPlayerManager {
         const simulatedPlayer = this._test!.spawnSimulatedPlayer({ x: 0, y: 8, z: 0 }, name);
         if (nameTag)
             simulatedPlayer.nameTag = nameTag;
-        simulatedPlayer.addTag('init');
         this.initialSigns.forEach(sign => simulatedPlayer.addTag(sign));
         try {
             //@ts-ignore

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -3,7 +3,7 @@ import { PIDManager, type PID } from "../pid";
 import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
 import SIGN from "../../constants/YumeSignEnum";
 import { SimulatedPlayerNotFoundError, UninitializedError } from "./errors";
-import type { AddSimulatedPlayerOptions } from "./types";
+import type { AddSimulatedPlayerOptions, SpawnSimulatedPlayerOptions } from "./types";
 
 const overworld = world.getDimension('overworld');
 
@@ -56,8 +56,10 @@ export class SimulatedPlayerManager {
         return `工具人-${pid}`;
     }
 
-    private spawn(location: Vector3, dimension: Dimension, name: string): SimulatedPlayer {
+    private spawn({ name, location, dimension, nameTag }: SpawnSimulatedPlayerOptions): SimulatedPlayer {
         const simulatedPlayer = this._test!.spawnSimulatedPlayer({ x: 0, y: 8, z: 0 }, name);
+        if (nameTag)
+            simulatedPlayer.nameTag = nameTag;
         simulatedPlayer.addTag('init');
         this.initialSigns.forEach(sign => simulatedPlayer.addTag(sign));
         try {
@@ -73,14 +75,13 @@ export class SimulatedPlayerManager {
         return simulatedPlayer;
     }
 
-    add({ name, location, dimension }: AddSimulatedPlayerOptions) {
+    add(options: AddSimulatedPlayerOptions) {
         if (!this.ready)
             throw new UninitializedError('call initialize() first');//改名
 
         const pid = this.pidManager.next();
-        name ??= this.generateName(pid);
 
-        const simulatedPlayer = this.spawn(location, dimension, name);
+        const simulatedPlayer = this.spawn({ ...options, name: options.name ?? this.generateName(pid) });
 
         this._pidToSimulatedPlayer.set(pid, simulatedPlayer);
         this._idToPid.set(simulatedPlayer.id, pid);

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -2,7 +2,7 @@ import { system, world, type Entity, type Vector3 } from "@minecraft/server";
 import { PIDManager, type PID } from "../pid";
 import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
 import SIGN from "../../constants/YumeSignEnum";
-import { SimulatedPlayerNotFoundError, UninitializedError } from "./errors";
+import { SimulatedPlayerNotFoundError, NotReadyError } from "./errors";
 import type { AddSimulatedPlayerOptions, SpawnSimulatedPlayerOptions } from "./types";
 
 const overworld = world.getDimension('overworld');
@@ -86,7 +86,7 @@ export class SimulatedPlayerManager {
 
     add(options: AddSimulatedPlayerOptions) {
         if (!this.ready)
-            throw new UninitializedError('call initialize() first');//改名
+            throw new NotReadyError('call initialize() and set test first');
 
         const pid = this.pidManager.next();
 

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -1,4 +1,4 @@
-import { system, world, type Dimension, type Entity, type Vector3 } from "@minecraft/server";
+import { system, world, type Entity, type Vector3 } from "@minecraft/server";
 import { PIDManager, type PID } from "../pid";
 import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
 import SIGN from "../../constants/YumeSignEnum";

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -34,7 +34,7 @@ export class SimulatedPlayerManager {
         };
     }
 
-    initialize() {//test 独立出单独方法？
+    initialize() {
         // 记分板PID初始化
         this.pidManager.initialize();
 

--- a/src/core/simulated-player/types.ts
+++ b/src/core/simulated-player/types.ts
@@ -6,3 +6,7 @@ export interface AddSimulatedPlayerOptions {
     dimension: Dimension;
     nameTag?: string;
 }
+
+export interface SpawnSimulatedPlayerOptions extends AddSimulatedPlayerOptions {
+    name: string;
+}

--- a/src/core/simulated-player/types.ts
+++ b/src/core/simulated-player/types.ts
@@ -1,0 +1,8 @@
+import type { Vector3, Dimension } from "@minecraft/server";
+
+export interface AddSimulatedPlayerOptions {
+    name?: string;
+    location: Vector3;
+    dimension: Dimension;
+    nameTag?: string;
+}

--- a/src/plugins/autoFishing.ts
+++ b/src/plugins/autoFishing.ts
@@ -7,7 +7,6 @@ fishingHookDespawned.subscribe(event=>{
 
     if(debug)console.error('fishingHook Despawned')
     if(debug)world.sendMessage("me ##鱼钩销毁\u000a鱼钩id=>"+event.HookId+"\u000a发起者id=>"+event.Fisher.id)
-    // TODO:has
 
     const simulatedPlayer = simulatedPlayerManager.get(event.Fisher.id);
     if (!simulatedPlayer) return;

--- a/src/plugins/autoFishing.ts
+++ b/src/plugins/autoFishing.ts
@@ -1,16 +1,17 @@
-import {simulatedPlayers} from './main'
 import {world} from "@minecraft/server";
 import {fishingHookDespawned, fishingHookSpawned} from "../lib/xboyEvents/fishingHookSpawned";
+import { simulatedPlayerManager } from "./main";
 
 const debug = false
 fishingHookDespawned.subscribe(event=>{
 
     if(debug)console.error('fishingHook Despawned')
     if(debug)world.sendMessage("me ##鱼钩销毁\u000a鱼钩id=>"+event.HookId+"\u000a发起者id=>"+event.Fisher.id)
-    for (const index in simulatedPlayers) {
-        const _ = simulatedPlayers[index]
-        !_ || _.id===event.Fisher.id?event.fishingHookDespawned_TickArray.push(()=>(_.useItemInSlot(0)?_.stopUsingItem():0)):0
-    }
+    // TODO:has
+
+    const simulatedPlayer = simulatedPlayerManager.get(event.Fisher.id);
+    if (!simulatedPlayer) return;
+    event.fishingHookDespawned_TickArray.push(() => (simulatedPlayer.useItemInSlot(0) ? simulatedPlayer.stopUsingItem() : 0));
 })
 fishingHookSpawned.subscribe(event=>{
     if(debug)console.error('fishingHook Spawned')

--- a/src/plugins/breakBlock.ts
+++ b/src/plugins/breakBlock.ts
@@ -1,10 +1,7 @@
 import type { SimulatedPlayer } from '@minecraft/server-gametest'
 import {Dimension, Player, Vector3} from '@minecraft/server'
 
-import {
-    simulatedPlayers,
-    testWorldLocation
-} from './main'
+import { testWorldLocation } from './main';
 import { Command, commandManager } from '../core/command';
 import { getSimPlayer } from '../utils/Util'
 import { world, system } from "@minecraft/server"
@@ -23,9 +20,7 @@ breakBlockCommand.register(({ args }) => args.length === 0, ({ entity, isEntity 
         return;
     } 
 
-    for(const i in simulatedPlayers)
-        if(simulatedPlayers[i]===SimPlayer)
-            SimPlayer.addTag(SIGN.AUTO_BREAKBLOCK_SIGN)
+    SimPlayer.addTag(SIGN.AUTO_BREAKBLOCK_SIGN)
 
     // console.error('[假人]内置插件'+'假人挖掘'+'执行成功')
 

--- a/src/plugins/chatSpawn.ts
+++ b/src/plugins/chatSpawn.ts
@@ -1,32 +1,22 @@
 import type {SimulatedPlayer} from '@minecraft/server-gametest'
 
-import {
-    initSucceed,
-    pidManager,
-    simulatedPlayers,
-    spawnSimulatedPlayer,
-    spawnSimulatedPlayerByNameTag
-} from './main'
+import { simulatedPlayerManager } from './main';
 import { type CommandInfo, commandManager, Command } from '../core/command'
 import { Dimension, Vector3, world, type Player } from '@minecraft/server'
 import {xyz_dododo} from "../utils/xyz_dododo";
+import { UninitializedError } from '../core/simulated-player';
 
 const overworld = world.getDimension("overworld");
 
 const spawnAndRegisterSimulatedPlayer = (entity: Player | undefined, location: Vector3, dimension: Dimension, nameTag?: string): void => {
-    if (!initSucceed) {
-        entity?.sendMessage('[假人] 插件未初始化完成，请重试');
-        return;
+    try {
+        simulatedPlayerManager.add({ name: nameTag, dimension, location });
+    } catch (e) {
+        if (e instanceof UninitializedError)
+            entity?.sendMessage('[假人] 插件未初始化完成，请重试');
+        else
+            throw e;
     }
-
-    const pid = pidManager.next();
-    const simulatedPlayer: SimulatedPlayer = nameTag
-        ? spawnSimulatedPlayerByNameTag(location, dimension, nameTag)
-        : spawnSimulatedPlayer(location, dimension, pid);
-
-
-    simulatedPlayers[pid] = simulatedPlayer;
-    simulatedPlayers[simulatedPlayer.id] = pid;
 };
 
 const chatSpawnCommand = new Command();

--- a/src/plugins/chatSpawn.ts
+++ b/src/plugins/chatSpawn.ts
@@ -2,7 +2,7 @@ import { simulatedPlayerManager } from './main';
 import { type CommandInfo, commandManager, Command } from '../core/command'
 import { Dimension, LocationOutOfWorldBoundariesError, Vector3, world, type Player } from '@minecraft/server'
 import {xyz_dododo} from "../utils/xyz_dododo";
-import { UninitializedError } from '../core/simulated-player';
+import { NotReadyError } from '../core/simulated-player';
 
 const overworld = world.getDimension("overworld");
 
@@ -10,7 +10,7 @@ const addSimulatedPlayer = (entity: Player | undefined, location: Vector3, dimen
     try {
         simulatedPlayerManager.add({ name: nameTag, dimension, location });
     } catch (e) {
-        if (e instanceof UninitializedError)
+        if (e instanceof NotReadyError)
             entity?.sendMessage('[假人] 插件未初始化完成，请重试');
         else if (e instanceof LocationOutOfWorldBoundariesError)
             entity?.sendMessage('[假人] 位置非法，请在合法位置重试');

--- a/src/plugins/chatSpawn.ts
+++ b/src/plugins/chatSpawn.ts
@@ -4,7 +4,6 @@ import {
     initSucceed,
     pidManager,
     simulatedPlayers,
-    spawned as spawnedEvent,
     spawnSimulatedPlayer,
     spawnSimulatedPlayerByNameTag
 } from './main'
@@ -28,8 +27,6 @@ const spawnAndRegisterSimulatedPlayer = (entity: Player | undefined, location: V
 
     simulatedPlayers[pid] = simulatedPlayer;
     simulatedPlayers[simulatedPlayer.id] = pid;
-
-    spawnedEvent.trigger({ spawnedSimulatedPlayer: simulatedPlayer, PID: pid });
 };
 
 const chatSpawnCommand = new Command();

--- a/src/plugins/chatSpawn.ts
+++ b/src/plugins/chatSpawn.ts
@@ -1,8 +1,6 @@
-import type {SimulatedPlayer} from '@minecraft/server-gametest'
-
 import { simulatedPlayerManager } from './main';
 import { type CommandInfo, commandManager, Command } from '../core/command'
-import { Dimension, Vector3, world, type Player } from '@minecraft/server'
+import { Dimension, LocationOutOfWorldBoundariesError, Vector3, world, type Player } from '@minecraft/server'
 import {xyz_dododo} from "../utils/xyz_dododo";
 import { UninitializedError } from '../core/simulated-player';
 
@@ -14,6 +12,8 @@ const spawnAndRegisterSimulatedPlayer = (entity: Player | undefined, location: V
     } catch (e) {
         if (e instanceof UninitializedError)
             entity?.sendMessage('[假人] 插件未初始化完成，请重试');
+        else if (e instanceof LocationOutOfWorldBoundariesError)
+            entity?.sendMessage('[假人] 位置非法，请在合法位置重试');
         else
             throw e;
     }

--- a/src/plugins/chatSpawn.ts
+++ b/src/plugins/chatSpawn.ts
@@ -6,7 +6,7 @@ import { UninitializedError } from '../core/simulated-player';
 
 const overworld = world.getDimension("overworld");
 
-const spawnAndRegisterSimulatedPlayer = (entity: Player | undefined, location: Vector3, dimension: Dimension, nameTag?: string): void => {
+const addSimulatedPlayer = (entity: Player | undefined, location: Vector3, dimension: Dimension, nameTag?: string): void => {
     try {
         simulatedPlayerManager.add({ name: nameTag, dimension, location });
     } catch (e) {
@@ -23,7 +23,7 @@ const chatSpawnCommand = new Command();
 
 // 假人生成
 chatSpawnCommand.register(({ args }) => args.length === 0, ({ entity, location }) => {
-    spawnAndRegisterSimulatedPlayer(entity, location, location.dimension);
+    addSimulatedPlayer(entity, location, location.dimension);
 });
 
 // 假人生成 批量 count
@@ -33,12 +33,12 @@ chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countS
 
     let count = Number(countString);
     while (count-- > 0)
-        spawnAndRegisterSimulatedPlayer(entity, location, location.dimension);
+        addSimulatedPlayer(entity, location, location.dimension);
 });
 
 // 假人生成 name
 chatSpawnCommand.register(({ args }) => args.length === 1, ({ args: [targetName], entity, location }) => {
-    spawnAndRegisterSimulatedPlayer(entity, location, location.dimension, targetName);
+    addSimulatedPlayer(entity, location, location.dimension, targetName);
 });
 
 // #56 参考：
@@ -84,7 +84,7 @@ chatSpawnCommand.register(
         }
         dimension ??= senderLocation.dimension ?? overworld;
 
-        spawnAndRegisterSimulatedPlayer(entity, location, dimension, nameTag);
+        addSimulatedPlayer(entity, location, dimension, nameTag);
     }
 );
 

--- a/src/plugins/gui.ts
+++ b/src/plugins/gui.ts
@@ -23,7 +23,7 @@ import { simulatedPlayerManager } from './main'
 world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
     const {player,target} = e
     if(!player || player.typeId!=='minecraft:player')return
-    if(!target || target.typeId!=='minecraft:player' || !simulatedPlayerManager.get(target.id))return// world.sendMessage('meow~ target');
+    if(!target || !simulatedPlayerManager.has(target))return// world.sendMessage('meow~ target');
     const SimPlayer = <SimulatedPlayer><unknown>target // what's unknow?
     if(!SimPlayer)return
     e.cancel=true

--- a/src/plugins/gui.ts
+++ b/src/plugins/gui.ts
@@ -9,8 +9,7 @@ import SIGN, {
 } from '../constants/YumeSignEnum'
 import { ActionFormData } from '@minecraft/server-ui'
 import { SimulatedPlayer } from '@minecraft/server-gametest'
-import { getSimPlayer } from '../utils/Util'
-import { simulatedPlayers } from './main'
+import { simulatedPlayerManager } from './main'
 
 // world.afterEvents.entityHitEntity.subscribe(({damagingEntity,hitEntity})=>{
 //     if(!damagingEntity || !hitEntity)return;
@@ -24,7 +23,7 @@ import { simulatedPlayers } from './main'
 world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
     const {player,target} = e
     if(!player || player.typeId!=='minecraft:player')return
-    if(!target || target.typeId!=='minecraft:player' || !simulatedPlayers[target.id])return// world.sendMessage('meow~ target');
+    if(!target || target.typeId!=='minecraft:player' || !simulatedPlayerManager.get(target.id))return// world.sendMessage('meow~ target');
     const SimPlayer = <SimulatedPlayer><unknown>target // what's unknow?
     if(!SimPlayer)return
     e.cancel=true

--- a/src/plugins/killedBySimPlayer.ts
+++ b/src/plugins/killedBySimPlayer.ts
@@ -1,11 +1,11 @@
 import type { Player } from '@minecraft/server';
 import entityDeadByHurt from '../lib/xboyEvents/entityDeadByHurt'
-import {simulatedPlayers} from './main'
+import { simulatedPlayerManager } from './main';
 
 entityDeadByHurt.subscribe(({ damageSource: { damagingEntity }, deadEntity }) => {
     if (deadEntity.typeId !== 'minecraft:player' || damagingEntity.typeId !== 'minecraft:player') return;
 
-    if (!(deadEntity.id in simulatedPlayers || damagingEntity.id in simulatedPlayers)) return;
+    if (!(simulatedPlayerManager.get(deadEntity.id) || simulatedPlayerManager.get(damagingEntity.id))) return;//TODO: 考虑has
 
     (<Player>damagingEntity).sendMessage('玩不起，就别玩');
     (<Player>deadEntity).sendMessage('菜，就多练');

--- a/src/plugins/killedBySimPlayer.ts
+++ b/src/plugins/killedBySimPlayer.ts
@@ -5,7 +5,7 @@ import { simulatedPlayerManager } from './main';
 entityDeadByHurt.subscribe(({ damageSource: { damagingEntity }, deadEntity }) => {
     if (deadEntity.typeId !== 'minecraft:player' || damagingEntity.typeId !== 'minecraft:player') return;
 
-    if (!(simulatedPlayerManager.get(deadEntity.id) || simulatedPlayerManager.get(damagingEntity.id))) return;//TODO: 考虑has
+    if (!(simulatedPlayerManager.has(deadEntity) || simulatedPlayerManager.has(damagingEntity))) return;
 
     (<Player>damagingEntity).sendMessage('玩不起，就别玩');
     (<Player>deadEntity).sendMessage('菜，就多练');

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -66,8 +66,6 @@ let testWorldLocation : Vector3
 if(!world.structureManager.get('xboyMinemcSIM:void'))
     world.structureManager.createEmpty('xboyMinemcSIM:void', { x:1, y:1, z:1 }).saveToWorld()
 
-export const initialized : initializedEventSignal = new EventSignal<initializedEvent>()
-
 register('我是云梦', '假人', (test:Test) => {
     testWorldLocation = test.worldBlockLocation({ x:0, y:0, z:0 })
     testWorldLocation["worldBlockLocation"] = (v3:Vector3)=> test.worldBlockLocation(v3)
@@ -103,7 +101,6 @@ register('我是云梦', '假人', (test:Test) => {
         return simulatedPlayer
     }
 
-    initialized.trigger(null)
     initSucceed = true
     console.log('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”')
 })

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -67,7 +67,6 @@ if(!world.structureManager.get('xboyMinemcSIM:void'))
     world.structureManager.createEmpty('xboyMinemcSIM:void', { x:1, y:1, z:1 }).saveToWorld()
 
 export const initialized : initializedEventSignal = new EventSignal<initializedEvent>()
-export const spawned : spawnedEventSignal = new EventSignal<spawnedEvent>()
 
 register('我是云梦', '假人', (test:Test) => {
     testWorldLocation = test.worldBlockLocation({ x:0, y:0, z:0 })

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -1,18 +1,6 @@
-import type { SimulatedPlayer, Test } from '@minecraft/server-gametest'
-import type {
-    initializedEvent,
-    initializedEventSignal,
-    spawnedEvent,
-    spawnedEventSignal,
-} from '../@types/globalThis'
-import {Dimension, LocationOutOfWorldBoundariesError, system, Vector3} from '@minecraft/server'
-
+import type { Test } from '@minecraft/server-gametest'
+import { Vector3 } from '@minecraft/server';
 import { register } from '@minecraft/server-gametest'
-
-import { PIDManager } from '../core/pid'
-import EventSignal from '../lib/xboyEvents/EventSignal'
-
-import { SIGN } from '../constants/YumeSignEnum'
 import { world } from '@minecraft/server'
 
 // import './plugins/noFlashDoor' // pig
@@ -35,15 +23,7 @@ import {playerMove} from "../lib/xboyEvents/move";
 import '../triggers'
 import { SimulatedPlayerManager } from '../core/simulated-player';
 
-const overworld = world.getDimension('overworld')
 const tickWaitTimes = 20*60*60*24*365
-// all of SimulatedPlayer List
-export const simulatedPlayers  = {}
-
-export let initSucceed = false
-
-export const pidManager = new PIDManager();
-
 
 let randomTickSpeed = 1
 let doDayLightCycle = true
@@ -76,7 +56,6 @@ register('我是云梦', '假人', (test:Test) => {
 
     simulatedPlayerManager.test = test
 
-    initSucceed = true
     console.log('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”')
 })
 .maxTicks(tickWaitTimes)
@@ -97,6 +76,7 @@ playerMove.subscribe(()=>{
     if (say) return
     say = true
     world.sendMessage('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”')
+    // TODO: 发送一次后解挂
 })
 
     // initialized.subscribe(()=> console.error('[模拟玩家]初始化完毕，加载内置插件') )

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -33,6 +33,7 @@ import './setting'
 import './showCommandsList'
 import {playerMove} from "../lib/xboyEvents/move";
 import '../triggers'
+import { SimulatedPlayerManager } from '../core/simulated-player';
 
 const overworld = world.getDimension('overworld')
 const tickWaitTimes = 20*60*60*24*365
@@ -58,8 +59,6 @@ let doMobSpawning = true
 }
 //  ?
 
-let spawnSimulatedPlayer : (location:Vector3, dimension:Dimension, pid: number  )=>SimulatedPlayer
-let spawnSimulatedPlayerByNameTag : (location:Vector3, dimension:Dimension, nameTag: string  )=>SimulatedPlayer
 let testWorldLocation : Vector3
 
 
@@ -75,31 +74,7 @@ register('我是云梦', '假人', (test:Test) => {
     world.gameRules.doDayLightCycle = doDayLightCycle
     world.gameRules.doMobSpawning = doMobSpawning
 
-    spawnSimulatedPlayer = (location:Vector3, dimension:Dimension, pid: number ):SimulatedPlayer=>{
-        return spawnSimulatedPlayerByNameTag(location, dimension, `工具人-${pid}`)
-    }
-    spawnSimulatedPlayerByNameTag = (location:Vector3, dimension:Dimension, nameTag: string ):SimulatedPlayer=>{
-
-        const simulatedPlayer = test.spawnSimulatedPlayer({ x:0, y:8, z:0 }, nameTag)
-        simulatedPlayer.addTag('init')
-        simulatedPlayer.addTag(SIGN.YUME_SIM_SIGN)
-        simulatedPlayer.addTag(SIGN.AUTO_RESPAWN_SIGN)
-        try {
-            //@ts-ignore
-            simulatedPlayer.setSpawnPoint({...location, dimension})
-            //@ts-ignore
-            simulatedPlayer.teleport(location, {dimension})
-        } catch (e) {
-            if (e instanceof LocationOutOfWorldBoundariesError) {
-                console.warn('[模拟玩家] 有东西尝试在非法位置生成假人，已阻止');
-                simulatedPlayer.disconnect();
-            } else {
-                throw e;
-            }
-        }
-
-        return simulatedPlayer
-    }
+    simulatedPlayerManager.test = test
 
     initSucceed = true
     console.log('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”')
@@ -111,20 +86,10 @@ register('我是云梦', '假人', (test:Test) => {
 // .requiredSuccessfulAttempts(tickWaitTimes)
 // .padding(0)
 
-    // @ts-ignore
-    (world.afterEvents.worldInitialize ?? world.afterEvents['worldLoad']).subscribe(()=>{
-
-    // 记分板PID初始化
-    pidManager.initialize();
-
-    const z = 11451400 +  Math.floor(Math.random() * 114514 * 19 )
-    system.run(()=>{
-        try {
-            overworld.runCommand('execute positioned 15000000 256 ' + z + ' run gametest run 我是云梦:假人');
-        } catch (e) {
-            world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);
-        }
-    });
+export const simulatedPlayerManager=new SimulatedPlayerManager();
+// @ts-ignore
+(world.afterEvents.worldInitialize ?? world.afterEvents['worldLoad']).subscribe(()=>{
+    simulatedPlayerManager.initialize();
 })
 
 let say = false
@@ -153,5 +118,5 @@ playerMove.subscribe(()=>{
     //
     // )
 
-export { spawnSimulatedPlayer,spawnSimulatedPlayerByNameTag,testWorldLocation }
+export { testWorldLocation }
 

--- a/src/plugins/setting.ts
+++ b/src/plugins/setting.ts
@@ -1,11 +1,11 @@
 import { Command, commandManager } from '../core/command'
-import { pidManager } from './main';
+import { simulatedPlayerManager } from './main';
 
 
 const settingsCommand = new Command()
 
 settingsCommand.register(({ entity }) => {
-    const PID = pidManager.reset()
+    const PID = simulatedPlayerManager.pidManager.reset()
     entity?.sendMessage('重置成功，重置前为'+PID)
 
 

--- a/src/plugins/setting.ts
+++ b/src/plugins/setting.ts
@@ -5,7 +5,7 @@ import { simulatedPlayerManager } from './main';
 const settingsCommand = new Command()
 
 settingsCommand.register(({ entity }) => {
-    const PID = simulatedPlayerManager.pidManager.reset()
+    const PID = simulatedPlayerManager.resetPID()
     entity?.sendMessage('重置成功，重置前为'+PID)
 
 


### PR DESCRIPTION
- ​**​新增功能与模块​**​:
  - 创建 `SimulatedPlayerManager` 模块，统一管理模拟玩家生命周期
  - 新增 `addSimulatedPlayer` 方法，支持对象字面量传参（含 `nameTag`）
  - 实现 `has` 方法，支持通过 PID、字符串 ID 或 Entity 实例判断目标是否为模拟玩家
  - 提取 `generatePosition` 方法解耦坐标生成逻辑，提升可维护性

- ​**​代码清理与重构​**​:
  - 移除未使用的 `spawn` 和 `initialized` 事件及相关代码（`spawnedEvent`、`initialized` 定义）
  - 删除废弃函数 `spawnSimulatedPlayer`、`spawnSimulatedPlayerByNameTag`
  - 清理冗余代码：未使用的导入（`Dimension`）、注释、`init` 标签及 `pidManager`
  - 重命名函数 `spawnAndRegisterSimulatedPlayer` → `addSimulatedPlayer`
  - 重命名错误类 `UninitializedError` → `NotReadyError`，更新所有引用

- ​**​错误处理与封装优化​**​:
  - 封装 `pidManager` 为私有属性，新增 `resetPID` 方法限制外部直接操作
  - 生成模拟玩家时捕获异常，自动移除无效实例并重抛错误
  - 拦截非法生成位置错误，向玩家发送友好提示消息

- ​**​插件与兼容性更新​**​:
  - 更新所有插件及 GUI 模块，适配 `SimulatedPlayerManager` 新接口
  - 简化 `main.ts` 初始化逻辑，直接注入 `simulatedPlayerManager` 实例