### PR TITLE
refactor: 在模块间迁移部分代码 并且调整 `TestManager` 的注册完成回调实现

### DIFF
--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -5,8 +5,6 @@ import SIGN from "../../constants/YumeSignEnum";
 import { SimulatedPlayerNotFoundError, NotReadyError } from "./errors";
 import type { AddSimulatedPlayerOptions, SpawnSimulatedPlayerOptions } from "./types";
 
-const overworld = world.getDimension('overworld');
-
 export class SimulatedPlayerManager {
     private readonly initialSigns = [
         SIGN.YUME_SIM_SIGN,
@@ -25,29 +23,10 @@ export class SimulatedPlayerManager {
         this._test = test;
     }
 
-    private generateTestPosition(): Vector3 {
-        const z = 11451400 + Math.floor(Math.random() * 114514 * 19);
-        return {
-            x: 15000000,
-            y: 256,
-            z
-        };
-    }
-
     initialize() {
         // 记分板PID初始化
         this.pidManager.initialize();
-
-        const { x, y, z } = this.generateTestPosition();
-
-        system.run(() => {
-            try {
-                overworld.runCommand(`execute positioned ${x} ${y} ${z} run gametest run 我是云梦:假人`);
-                this._initialized = true;
-            } catch (e) {
-                world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);
-            }
-        });
+        this._initialized = true;
     }
 
     get ready(): boolean {

--- a/src/core/test/manager.ts
+++ b/src/core/test/manager.ts
@@ -1,11 +1,17 @@
-import { world, type Vector3 } from "@minecraft/server";
+import { system, world, type Vector3 } from "@minecraft/server";
 import { register, type Test } from "@minecraft/server-gametest";
+
+const overworld = world.getDimension('overworld');
 
 export class TestManager {
     private readonly maxTicks = 20 * 60 * 60 * 24 * 365;
     private _testLocation: Vector3;
     private _test: Test | undefined;
-    private callback: () => void = () => {};
+
+    private _resolve: (value: Test | PromiseLike<Test>) => void;
+    public readonly ready = new Promise<Test>(resolve => {
+        this._resolve = resolve;
+    });
 
     get testLocation(): Vector3 {
         return this._testLocation;
@@ -29,7 +35,7 @@ export class TestManager {
             world.gameRules.doMobSpawning = doMobSpawning;
 
             this._test = test;
-            this.callback();
+            this._resolve(test);
 
             console.log('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”');
         })
@@ -37,7 +43,24 @@ export class TestManager {
             .structureName('xboyMinemcSIM:void');
     }
 
-    onRegistered(callback: () => void): void {
-        this.callback = callback;
+    private generateTestPosition(): Vector3 {
+        const z = 11451400 + Math.floor(Math.random() * 114514 * 19);
+        return {
+            x: 15000000,
+            y: 256,
+            z
+        };
+    }
+
+    initialize(): void {
+        const { x, y, z } = this.generateTestPosition();
+
+        system.run(() => {
+            try {
+                overworld.runCommand(`execute positioned ${x} ${y} ${z} run gametest run 我是云梦:假人`);
+            } catch (e) {
+                world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);
+            }
+        });
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,14 +10,15 @@ import { TestManager } from './core/test/manager';
 export const simulatedPlayerManager=new SimulatedPlayerManager();
 
 export const testManager = new TestManager()
-testManager.onRegistered(()=>{
-    simulatedPlayerManager.test=testManager.test
-})
+testManager.ready.then(test => {
+    simulatedPlayerManager.test = test;
+});
 testManager.registerTest();
 
-world.afterEvents.worldLoad.subscribe(()=>{
+world.afterEvents.worldLoad.subscribe(() => {
     simulatedPlayerManager.initialize();
-})
+    testManager.initialize();
+});
 
 const broadcast = () => {
     world.sendMessage('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”');


### PR DESCRIPTION
- 迁移部分代码从模块 `simulated-player` 到 `test`
- `TestManager` 现在通过 ready 属性（一个 `Promise`）等待完成，`ready` 会携带 `test` 对象兑现

明确模块边界