### PR TITLE
refactor: `playerMove` 事件优化及代码清理

### DIFF
--- a/src/@types/globalThis.d.ts
+++ b/src/@types/globalThis.d.ts
@@ -238,7 +238,7 @@ export class projectileFiredEventSignal {
     trigger(projectileFired: projectileFiredEvent): void;
     protected constructor();
 }
-export class playerMoveAfterEventSignal {
+export class playerReadyAfterEventSignal {
     subscribe(undefined): void;
     unsubscribe(undefined): void;
     trigger(undefined): void;

--- a/src/@types/globalThis.d.ts
+++ b/src/@types/globalThis.d.ts
@@ -238,37 +238,8 @@ export class projectileFiredEventSignal {
     trigger(projectileFired: projectileFiredEvent): void;
     protected constructor();
 }
-export class playerMoveAfterEvent {
-    /**
-     * @remarks
-     * Describes the location after move.
-     *
-     */
-    readonly location: Vector3;
-    /**
-     * @remarks
-     * Describes the viewDirection after move.
-     *
-     */
-    readonly viewDirection: Vector3;
-    /**
-     * @remarks
-     * Describes the location before move.
-     *
-     */
-    readonly locationBefore: Vector3;
-    /**
-     * @remarks
-     * Describes the viewDirection before move.
-     *
-     */
-    readonly viewDirectionBefore: Vector3;
-}
-
-
-
 export class playerMoveAfterEventSignal {
-    subscribe(callback: (arg: playerMoveAfterEvent) => void): (arg: playerMoveAfterEvent) => void;
-    unsubscribe(callback: (arg: playerMoveAfterEvent) => void): void;
-    trigger(playerMoveAfterEvent: playerMoveAfterEvent): void;
+    subscribe(undefined): void;
+    unsubscribe(undefined): void;
+    trigger(undefined): void;
 }

--- a/src/lib/xboyEvents/index.ts
+++ b/src/lib/xboyEvents/index.ts
@@ -2,10 +2,10 @@ import entityDeadByHurt from "./entityDeadByHurt"
 import { fishingHookSpawned, fishingHookDespawned } from "./fishingHookSpawned"
 import reloadFromCmd from "./reloadFromCmd"
 // import  "./projectileFired"; // TEST
-import { playerMove } from "./move";
+import { playerReady } from "./ready";
 
 const events = {
-    playerMove: playerMove,
+    playerMove: playerReady,
     entityDeadByHurt: entityDeadByHurt,
     fishingHookSpawned: fishingHookSpawned,
     fishingHookDespawned: fishingHookDespawned

--- a/src/lib/xboyEvents/move.ts
+++ b/src/lib/xboyEvents/move.ts
@@ -1,40 +1,34 @@
 import { type Player, system,type Vector3, world} from "@minecraft/server"
 import EventSignal from "./EventSignal";
-import type { playerMoveAfterEvent, playerMoveAfterEventSignal } from "../../@types/globalThis";
+import type { playerMoveAfterEventSignal } from "../../@types/globalThis";
 
 
 
 // EventSignal
-export const playerMove:playerMoveAfterEventSignal = new EventSignal<playerMoveAfterEvent>()
+export const playerMove:playerMoveAfterEventSignal = new EventSignal<undefined>()
 // console.error(JSON.stringify(world.getAllPlayers()[0].getViewDirection()))
 
-const playerInfo = new Map<Player,{location:Vector3,viewDirection: Vector3,flash:string}>()
-
-const getFlash = ({x,y,z}:Vector3)=>    String(x)+String(y)+String(z)
-
+const playerViewYMap = new Map<Player, number>()
 
 const update = ()=>{
     const playerList = world.getAllPlayers()
           playerList.forEach(player=>{
-              const location = player.location
-              const viewDirection = player.getViewDirection()
-              const flash = getFlash(location)+getFlash(viewDirection)
-              const lastInfo = playerInfo.get(player)
+              const {y: currentViewY} = player.getViewDirection()
+              
+              const storedViewY = playerViewYMap.get(player)
+              
+              if(storedViewY===undefined)
+                // set to Map
+            return playerViewYMap.set(player, currentViewY)
+            
+            if(storedViewY==currentViewY)
+                // nothing
+                return
+            
+            // update to Map && Event-trigger
+            playerViewYMap.set(player, currentViewY)
+              playerMove.trigger(undefined)
 
-
-              if(lastInfo===undefined)
-                  // set to Map
-                  return playerInfo.set(player,{location,viewDirection,flash})
-
-              if(lastInfo.flash==flash)
-                  // nothing
-                  return void flash
-
-              // update to Map && Event-trigger
-              playerInfo.set(player,{location,viewDirection,flash})
-              const {location:locationBefore,viewDirection:viewDirectionBefore} = playerInfo.get(player)
-              playerMove.trigger({location, viewDirection,locationBefore,viewDirectionBefore})
-         
               system.clearRun(id)
           })
 }

--- a/src/lib/xboyEvents/move.ts
+++ b/src/lib/xboyEvents/move.ts
@@ -39,5 +39,5 @@ const update = ()=>{
 
 // export default  playerMove
 
-system.runInterval(update,0)
+system.runInterval(update,4)
 

--- a/src/lib/xboyEvents/move.ts
+++ b/src/lib/xboyEvents/move.ts
@@ -34,10 +34,11 @@ const update = ()=>{
               playerInfo.set(player,{location,viewDirection,flash})
               const {location:locationBefore,viewDirection:viewDirectionBefore} = playerInfo.get(player)
               playerMove.trigger({location, viewDirection,locationBefore,viewDirectionBefore})
+         
+              system.clearRun(id)
           })
 }
 
 // export default  playerMove
 
-system.runInterval(update,4)
-
+const id=system.runInterval(update,4)

--- a/src/lib/xboyEvents/ready.ts
+++ b/src/lib/xboyEvents/ready.ts
@@ -1,8 +1,6 @@
-import { type Player, system,type Vector3, world} from "@minecraft/server"
+import { type Player, system,world} from "@minecraft/server"
 import EventSignal from "./EventSignal";
 import type { playerReadyAfterEventSignal } from "../../@types/globalThis";
-
-
 
 // EventSignal
 export const playerReady:playerReadyAfterEventSignal = new EventSignal<undefined>()

--- a/src/lib/xboyEvents/ready.ts
+++ b/src/lib/xboyEvents/ready.ts
@@ -1,11 +1,11 @@
 import { type Player, system,type Vector3, world} from "@minecraft/server"
 import EventSignal from "./EventSignal";
-import type { playerMoveAfterEventSignal } from "../../@types/globalThis";
+import type { playerReadyAfterEventSignal } from "../../@types/globalThis";
 
 
 
 // EventSignal
-export const playerMove:playerMoveAfterEventSignal = new EventSignal<undefined>()
+export const playerReady:playerReadyAfterEventSignal = new EventSignal<undefined>()
 // console.error(JSON.stringify(world.getAllPlayers()[0].getViewDirection()))
 
 const playerViewYMap = new Map<Player, number>()
@@ -27,7 +27,7 @@ const update = ()=>{
             
             // update to Map && Event-trigger
             playerViewYMap.set(player, currentViewY)
-              playerMove.trigger(undefined)
+              playerReady.trigger(undefined)
 
               system.clearRun(id)
           })

--- a/src/lib/xboyEvents/ready.ts
+++ b/src/lib/xboyEvents/ready.ts
@@ -7,17 +7,18 @@ export const playerReady: playerReadyAfterEventSignal = new EventSignal<undefine
 
 const playerViewYMap = new Map<Player, number>();
 
-const update = () => {
+const update = (): void => {
     const playerList = world.getAllPlayers();
     playerList.forEach(player => {
         const { y: currentViewY } = player.getViewDirection();
 
         const storedViewY = playerViewYMap.get(player);
 
-        if (storedViewY === undefined)
+        if (storedViewY === undefined) {
             // set to Map
-            return playerViewYMap.set(player, currentViewY);
-
+            playerViewYMap.set(player, currentViewY);
+            return;
+        }
         if (storedViewY == currentViewY)
             // nothing
             return;

--- a/src/lib/xboyEvents/ready.ts
+++ b/src/lib/xboyEvents/ready.ts
@@ -1,33 +1,33 @@
-import { type Player, system,world} from "@minecraft/server"
+import { type Player, system, world } from "@minecraft/server";
 import EventSignal from "./EventSignal";
 import type { playerReadyAfterEventSignal } from "../../@types/globalThis";
 
 // EventSignal
-export const playerReady:playerReadyAfterEventSignal = new EventSignal<undefined>()
+export const playerReady: playerReadyAfterEventSignal = new EventSignal<undefined>();
 
-const playerViewYMap = new Map<Player, number>()
+const playerViewYMap = new Map<Player, number>();
 
-const update = ()=>{
-    const playerList = world.getAllPlayers()
-          playerList.forEach(player=>{
-              const {y: currentViewY} = player.getViewDirection()
-              
-              const storedViewY = playerViewYMap.get(player)
-              
-              if(storedViewY===undefined)
-                // set to Map
-            return playerViewYMap.set(player, currentViewY)
-            
-            if(storedViewY==currentViewY)
-                // nothing
-                return
-            
-            // update to Map && Event-trigger
-            playerViewYMap.set(player, currentViewY)
-              playerReady.trigger(undefined)
+const update = () => {
+    const playerList = world.getAllPlayers();
+    playerList.forEach(player => {
+        const { y: currentViewY } = player.getViewDirection();
 
-              system.clearRun(id)
-          })
-}
+        const storedViewY = playerViewYMap.get(player);
 
-const id=system.runInterval(update,4)
+        if (storedViewY === undefined)
+            // set to Map
+            return playerViewYMap.set(player, currentViewY);
+
+        if (storedViewY == currentViewY)
+            // nothing
+            return;
+
+        // update to Map && Event-trigger
+        playerViewYMap.set(player, currentViewY);
+        playerReady.trigger(undefined);
+
+        system.clearRun(id);
+    });
+};
+
+const id = system.runInterval(update, 4);

--- a/src/lib/xboyEvents/ready.ts
+++ b/src/lib/xboyEvents/ready.ts
@@ -6,7 +6,6 @@ import type { playerReadyAfterEventSignal } from "../../@types/globalThis";
 
 // EventSignal
 export const playerReady:playerReadyAfterEventSignal = new EventSignal<undefined>()
-// console.error(JSON.stringify(world.getAllPlayers()[0].getViewDirection()))
 
 const playerViewYMap = new Map<Player, number>()
 
@@ -32,7 +31,5 @@ const update = ()=>{
               system.clearRun(id)
           })
 }
-
-// export default  playerMove
 
 const id=system.runInterval(update,4)

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,8 +20,6 @@ world.afterEvents.worldLoad.subscribe(() => {
     testManager.initialize();
 });
 
-const broadcast = () => {
+playerMove.subscribe(() => {
     world.sendMessage('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”');
-    playerMove.unsubscribe(broadcast);
-};
-playerMove.subscribe(broadcast);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { world } from '@minecraft/server'
 
 import './features'
 
-import {playerMove} from "./lib/xboyEvents/move";
+import {playerReady} from "./lib/xboyEvents/ready";
 import './triggers'
 import { SimulatedPlayerManager } from './core/simulated-player';
 import { TestManager } from './core/test/manager';
@@ -20,6 +20,6 @@ world.afterEvents.worldLoad.subscribe(() => {
     testManager.initialize();
 });
 
-playerMove.subscribe(() => {
+playerReady.subscribe(() => {
     world.sendMessage('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”');
 });


### PR DESCRIPTION
### refactor
- 将 `playerMove` 事件重命名为 `playerReady`，以贴切新实现的语义
- 简化事件参数：移除未使用的信息对象，改为无参事件
- 解除 main.ts 中不再必要的注销逻辑
- 清理废弃代码：移除被注释的代码块
- 删除未使用的模块导入
- 显式指定箭头函数返回值类型
- 统一代码格式规范
- 移除快照相关功能

### perf
- 调整轮询间隔：从 0tick 优化至 4ticks
- 单次触发机制：事件触发后自动停止轮询
- 简化观测维度：仅保留 y 视角的观测