### PR TITLE
refactor: `command` 模块支持简单注册模式

### DIFF
--- a/src/core/command/command.ts
+++ b/src/core/command/command.ts
@@ -3,7 +3,7 @@ import type {
     DimensionLocation,
     Vector3
 } from "@minecraft/server";
-import type { CommandInfo, CommandHandler } from "./types";
+import type { Executable, CommandInfo, CommandHandler } from "./types";
 
 /**
  * 解析命令字符串。
@@ -29,7 +29,7 @@ export function getLocationFromEntityLike(entity: {
 export const internalExceptionWarningText = '[模拟玩家] 出现内部异常，已尝试处理，请在GitHub进行反馈以免再次出现问题';
 export const cannotHandledExceptionWarningText = '[模拟玩家] 出现不可处理的内部异常，请在GitHub进行反馈';
 
-export class Command {
+export class Command implements Executable {
     private conditionsHandlers = new Map<(cmdInfo: CommandInfo) => boolean, CommandHandler[]>();
 
     /**

--- a/src/core/command/types.ts
+++ b/src/core/command/types.ts
@@ -1,6 +1,10 @@
 import type { Player, DimensionLocation } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
+export interface Executable {
+    execute: (commandInfo: CommandInfo) => void;
+}
+
 export interface CommandInfo {
     prefix: string;
     args: string[];
@@ -9,6 +13,7 @@ export interface CommandInfo {
     isEntity?: boolean;
     sim?: SimulatedPlayer;
 } // | Player | Dimension | Entity
+
 export type CommandInfoNoArgs = Omit<CommandInfo, "args" | "prefix">;
 
 export type CommandHandler = (cmdInfo: CommandInfo) => void;

--- a/src/features/behaviors.ts
+++ b/src/features/behaviors.ts
@@ -1,6 +1,6 @@
 import SIGN from '../constants/YumeSignEnum';
 import { getSimPlayer } from '../core/queries/Util';
-import { Command, commandManager } from '../core/command';
+import { commandManager } from '../core/command';
 
 interface BehaviorCommandConfig {
     behavior: string;
@@ -71,11 +71,9 @@ const behaviorCommandConfigs: BehaviorCommandConfig[] = [
 
 const behaviorPrefix = '假人';
 
-// HACK: 兼容 v8 的命令形式，需要考虑优化方式
 const registerBehaviorCommands = () => {
     behaviorCommandConfigs.forEach(behaviorCommand => {
-        const command = new Command();
-        command.register(({ entity }) => {
+        commandManager.registerCommand(`${behaviorPrefix}${behaviorCommand.behavior}`, ({ entity }) => {
             if (!entity) return;
             const simulatedPlayer = getSimPlayer.fromView(entity);
             if (!simulatedPlayer) return;
@@ -89,7 +87,6 @@ const registerBehaviorCommands = () => {
                 simulatedPlayer.removeTag(tag);
             });
         });
-        commandManager.registerCommand(`${behaviorPrefix}${behaviorCommand.behavior}`, command);
     });
 };
 

--- a/src/features/setting.ts
+++ b/src/features/setting.ts
@@ -1,15 +1,10 @@
-import { Command, commandManager } from '../core/command'
+import { commandManager } from '../core/command'
 import { simulatedPlayerManager } from '../main';
 
-
-const settingsCommand = new Command()
-
-settingsCommand.register(({ entity }) => {
+commandManager.registerCommand(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ entity }) => {
     const PID = simulatedPlayerManager.resetPID()
     entity?.sendMessage('重置成功，重置前为'+PID)
 
 
     entity?.sendMessage('以前是以前✋ ，现在是现在✋ ，你要是一直拿以前当作现在✋ ，哥们，你怎么不拿你开新档的时候对比')
-})
-
-commandManager.registerCommand(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], settingsCommand);
+});

--- a/src/features/showCommandsList.ts
+++ b/src/features/showCommandsList.ts
@@ -1,7 +1,5 @@
-import { Command, commandManager } from "../core/command";
+import { commandManager } from "../core/command";
 
-const listCommands = new Command();
-listCommands.register(({ entity }) => {
+commandManager.registerCommand(['showshowway', '假人命令列表'], ({ entity }) => {
     entity?.sendMessage(commandManager.listRegisteredPrefixes().join('\n'));
 });
-commandManager.registerCommand(['showshowway', '假人命令列表'], listCommands);

--- a/src/features/youAreMine.ts
+++ b/src/features/youAreMine.ts
@@ -1,6 +1,6 @@
 import type { SimulatedPlayer } from '@minecraft/server-gametest'
 import { getSimPlayer } from '../core/queries/Util'
-import { Command, commandManager, getLocationFromEntityLike } from '../core/command';
+import { commandManager, getLocationFromEntityLike } from '../core/command';
 import {
     EntityEquippableComponent,
     EntityInventoryComponent,
@@ -29,8 +29,7 @@ const dimensionMap: Record<string, string> = {
 
 // swapMainhandItem
 // commandRegistry.registerAlias('swapInventory','假人主手物品交换')
-const mainhandItemSwapCommand = new Command();
-mainhandItemSwapCommand.register(({entity,sim}) => {
+commandManager.registerCommand('假人主手物品交换', ({entity,sim}) => {
 
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
 
@@ -43,13 +42,11 @@ mainhandItemSwapCommand.register(({entity,sim}) => {
     s.setEquipment(<EquipmentSlot>i, __)
     p.setEquipment(<EquipmentSlot>i, _)
 });
-commandManager.registerCommand('假人主手物品交换', mainhandItemSwapCommand);
 
 
 // swapOffhandItem
 // commandRegistry.registerAlias('swapInventory','假人副手物品交换')
-const offhandItemSwapCommand = new Command();
-offhandItemSwapCommand.register(({entity,sim}) => {
+commandManager.registerCommand('假人副手物品交换', ({entity,sim}) => {
 
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
 
@@ -62,13 +59,11 @@ offhandItemSwapCommand.register(({entity,sim}) => {
     s.setEquipment(<EquipmentSlot>i, __)
     p.setEquipment(<EquipmentSlot>i, _)
 });
-commandManager.registerCommand('假人副手物品交换', offhandItemSwapCommand);
 
 
 // swapInventory
 // commandRegistry.registerAlias('swapInventory','假人背包交换')
-const inventorySwapCommand = new Command();
-inventorySwapCommand.register(({entity,isEntity,sim}) => {
+commandManager.registerCommand(['假人背包交换','假人交换背包'], ({entity,isEntity,sim}) => {
     if(!isEntity && !sim)return
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
     if(!SimPlayer)return
@@ -93,13 +88,11 @@ inventorySwapCommand.register(({entity,isEntity,sim}) => {
     ) ;
 
 });
-commandManager.registerCommand(['假人背包交换','假人交换背包'], inventorySwapCommand);
 
 
 // swapEquipment
 // commandRegistry.registerAlias('swapEquipment','假人装备交换')
-const equipmentSwapCommand = new Command();
-equipmentSwapCommand.register(({entity,isEntity,sim}) => {
+commandManager.registerCommand(['假人装备交换','假人交换装备'], ({entity,isEntity,sim}) => {
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
     if(!isEntity && !sim)return
 
@@ -116,12 +109,10 @@ equipmentSwapCommand.register(({entity,isEntity,sim}) => {
         p.setEquipment(<EquipmentSlot>i, _) //set player item
     }
 });
-commandManager.registerCommand(['假人装备交换','假人交换装备'], equipmentSwapCommand);
 
 
 // recycle item and exp
-const returnResCommand = new Command();
-returnResCommand.register(({entity,isEntity,sim})=>{
+commandManager.registerCommand(['假人资源回收','假人背包清空','假人爆金币'], ({entity,isEntity,sim})=>{
     if(!isEntity && !sim) {
         console.error('error not isEntity')
         return
@@ -164,12 +155,10 @@ returnResCommand.register(({entity,isEntity,sim})=>{
         entity.playSound('random.levelup');
     }
 });
-commandManager.registerCommand(['假人资源回收','假人背包清空','假人爆金币'], returnResCommand);
 
 
 // disconnect
-const disconnectCommand = new Command();
-disconnectCommand.register(({entity,isEntity,args:[simIndex],sim}) => {
+commandManager.registerCommand(['假人销毁','假人移除','假人清除'], ({entity,isEntity,args:[simIndex],sim}) => {
     if(sim)return simulatedPlayerManager.remove(sim);
 
     if(!isEntity) {
@@ -199,11 +188,10 @@ disconnectCommand.register(({entity,isEntity,args:[simIndex],sim}) => {
     }
 
 });
-commandManager.registerCommand(['假人销毁','假人移除','假人清除'], disconnectCommand);
 
 // respawn
-const respawnCommand = new Command();
-respawnCommand.register(({entity,isEntity,args:[simIndex]}) => {
+commandManager.registerCommand(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'],
+    ({ entity, isEntity, args: [simIndex] }) => {
 
     if (!isEntity && simIndex === undefined) {
         console.error('error not isEntity')
@@ -234,12 +222,10 @@ respawnCommand.register(({entity,isEntity,args:[simIndex]}) => {
     }
 
 });
-commandManager.registerCommand(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'], respawnCommand);
 
 
 // time
-const timeCommand = new Command();
-timeCommand.register(({entity}) => {
+commandManager.registerCommand(['假人时区', '假人时间'], ({entity}) => {
     // entity.sendMessage(''+Intl.DateTimeFormat().resolvedOptions().timeZone)
 
     const now = new Date()
@@ -251,11 +237,9 @@ timeCommand.register(({entity}) => {
     entity.sendMessage(`UTC偏移量：${offsetHours} 小时`)
     entity.sendMessage(`TicksPerSecond：${TicksPerSecond}`)
 });
-commandManager.registerCommand(['假人时区', '假人时间'], timeCommand);
 
 // List
-const listCommand = new Command();
-listCommand.register(({entity}) => {
+commandManager.registerCommand('假人列表', ({entity}) => {
     let target = entity ?? world;
     if (simulatedPlayerManager.simulatedPlayers.size === 0) return target.sendMessage('列表空的');
     for (const [index, simulatedPlayer] of simulatedPlayerManager.simulatedPlayers) {
@@ -263,11 +247,9 @@ listCommand.register(({entity}) => {
         target.sendMessage(message);
     }
 });
-commandManager.registerCommand('假人列表', listCommand);
 
 // rename
-const renameCommand = new Command();
-renameCommand.register(({entity,isEntity,args:[newName]}) => {
+commandManager.registerCommand(['假人改名', '假人重命名', '假人换名'], ({entity,isEntity,args:[newName]}) => {
     if(!isEntity) {
         console.error('error not isEntity')
         return
@@ -283,12 +265,10 @@ renameCommand.register(({entity,isEntity,args:[newName]}) => {
     SimPlayer.nameTag = newName;
     entity.sendMessage("§e§l-改名成功")
 });
-commandManager.registerCommand(['假人改名', '假人重命名', '假人换名'], renameCommand);
 
 
 // location
-const locationCommand = new Command();
-locationCommand.register(({ entity, isEntity, args: [simIndex] }) => {
+commandManager.registerCommand(['假人位置', '假人坐标'], ({ entity, isEntity, args: [simIndex] }) => {
     if (!isEntity && simIndex === undefined) {
         console.error('error not isEntity');
         return;
@@ -312,7 +292,6 @@ locationCommand.register(({ entity, isEntity, args: [simIndex] }) => {
     const { x, y, z } = simulatedPlayer.location;
     entity.sendMessage(`§e§l${simulatedPlayer.name} 位于 ${dimensionMap[simulatedPlayer.dimension.id] ?? simulatedPlayer.dimension.id}(${x.toFixed(2)}, ${y.toFixed(2)}, ${z.toFixed(2)})`);
 });
-commandManager.registerCommand(['假人位置', '假人坐标'], locationCommand);
 // 你懂的~
 // youAreMine
 // ~


### PR DESCRIPTION


_command 模块_

-   该模块现在支持直接注册函数，并且存储方式统一
-   `manager` 现在依赖抽象接口，提高扩展性
-   `command` 中 `Command` 类现在实现抽象接口

对于无需分支逻辑的命令，可以简化注册过程

_其他模块_
以下模块中的代码改用了简单注册

-   _features/_
    -   youAreMine.ts
    -   showCommandList.ts
    -   settings.ts
    -   behaviors.ts
