### PR TITLE
refactor: 删除不再需要的类型断言和 ts 忽略

### DIFF
--- a/src/constants/YumeSignEnum.ts
+++ b/src/constants/YumeSignEnum.ts
@@ -62,7 +62,6 @@ export enum  BEHAVIOR_ZH {
 }
 
 export const BEHAVIOR_FUNCTION = {
-    // @ts-ignore
     lookAtEntity : (sim:SimulatedPlayer,player:Player)=>sim.lookAtEntity(player,LookDuration.Instant),
     teleport : (sim:SimulatedPlayer,player:Player)=>sim.teleport(player.location),
     useAndStopUsingItem : (sim:SimulatedPlayer&Player)=>sim.useItemInSlot(sim.selectedSlotIndex) && sim.stopUsingItem(),
@@ -75,7 +74,7 @@ export const BEHAVIOR_FUNCTION = {
     rename: async (sim: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
         modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', sim.nameTag);
-        const { canceled, formValues } = await modalForm.show(<any>player);
+        const { canceled, formValues } = await modalForm.show(player);
         if (canceled) return;
 
         sim.nameTag = <string>formValues[0];

--- a/src/core/queries/Util.ts
+++ b/src/core/queries/Util.ts
@@ -6,7 +6,7 @@ import SIGN from '@/constants/YumeSignEnum'
 // getEntitiesFromViewDirection
 export const getSimPlayer = {
     // only one
-    fromView: (e:Entity,maxDistance=16):SimulatedPlayer=>(<SimulatedPlayer><unknown>e.getEntitiesFromViewDirection({maxDistance}).find(({entity}) => entity.hasTag(SIGN.YUME_SIM_SIGN))?.entity),
+    fromView: (e:Entity,maxDistance=16):SimulatedPlayer=>(<SimulatedPlayer>e.getEntitiesFromViewDirection({maxDistance}).find(({entity}) => entity.hasTag(SIGN.YUME_SIM_SIGN))?.entity),
 
 }
 

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -51,9 +51,7 @@ export class SimulatedPlayerManager {
             simulatedPlayer.nameTag = nameTag;
         this.initialSigns.forEach(sign => simulatedPlayer.addTag(sign));
         try {
-            //@ts-ignore
             simulatedPlayer.setSpawnPoint({ ...location, dimension });
-            //@ts-ignore
             simulatedPlayer.teleport(location, { dimension });
         } catch (e) {
             simulatedPlayer.disconnect();

--- a/src/features/commands/handlers/behaviors/break-block.ts
+++ b/src/features/commands/handlers/behaviors/break-block.ts
@@ -26,7 +26,7 @@ commandManager.registerCommand(['假人挖掘', '假人摧毁'], breakBlockComma
 // task
 const breaks = () =>
     world.getPlayers({ tags: [SIGN.AUTO_BREAKBLOCK_SIGN] }).forEach(async SimPlayer => {
-        const man = <SimulatedPlayer><unknown>SimPlayer;
+        const man = <SimulatedPlayer>SimPlayer;
         const block = man.getBlockFromViewDirection({ maxDistance: 6 })?.block;
         if (!block) return;
 

--- a/src/features/commands/handlers/inventory/equipment-swap.ts
+++ b/src/features/commands/handlers/inventory/equipment-swap.ts
@@ -1,13 +1,13 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries/Util";
-import { EquipmentSlot, type EntityEquippableComponent } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand(['假人装备交换','假人交换装备'], ({entity,isEntity,sim}) => {
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
     if(!isEntity && !sim)return
 
-    const s = <EntityEquippableComponent><unknown>SimPlayer.getComponent("minecraft:equippable") // SimPlayer
+    const s = SimPlayer.getComponent("minecraft:equippable") // SimPlayer
 
     const p = entity.getComponent("minecraft:equippable") // player
     for (const i in  EquipmentSlot) {

--- a/src/features/commands/handlers/inventory/inventory-swap.ts
+++ b/src/features/commands/handlers/inventory/inventory-swap.ts
@@ -1,6 +1,5 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries/Util";
-import type { EntityInventoryComponent } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand(['假人背包交换','假人交换背包'], ({entity,isEntity,sim}) => {
@@ -8,7 +7,7 @@ commandManager.registerCommand(['假人背包交换','假人交换背包'], ({en
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
     if(!SimPlayer)return
 
-    const s = (<EntityInventoryComponent><unknown>SimPlayer.getComponent("minecraft:inventory")).container
+    const s = SimPlayer.getComponent("minecraft:inventory").container
 
     const p = entity.getComponent("minecraft:inventory").container
 

--- a/src/features/commands/handlers/inventory/mainhand-swap.ts
+++ b/src/features/commands/handlers/inventory/mainhand-swap.ts
@@ -1,13 +1,13 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries/Util";
-import { EquipmentSlot, type EntityEquippableComponent } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand('假人主手物品交换', ({entity,sim}) => {
 
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
 
-    const s = <EntityEquippableComponent><unknown>SimPlayer.getComponent("minecraft:equippable")
+    const s = SimPlayer.getComponent("minecraft:equippable")
 
     const p = entity.getComponent("minecraft:equippable")
     const i = EquipmentSlot['Mainhand'] ?? EquipmentSlot['mainhand']

--- a/src/features/commands/handlers/inventory/offhand-swap.ts
+++ b/src/features/commands/handlers/inventory/offhand-swap.ts
@@ -1,13 +1,13 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries/Util";
-import { EquipmentSlot, type EntityEquippableComponent } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand('假人副手物品交换', ({entity,sim}) => {
 
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
 
-    const s = <EntityEquippableComponent><unknown>SimPlayer.getComponent("minecraft:equippable")
+    const s = SimPlayer.getComponent("minecraft:equippable")
 
     const p = entity.getComponent("minecraft:equippable")
     const i = EquipmentSlot['Offhand'] ?? EquipmentSlot['offhand']

--- a/src/features/commands/handlers/inventory/recycle.ts
+++ b/src/features/commands/handlers/inventory/recycle.ts
@@ -1,6 +1,6 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries/Util";
-import { EquipmentSlot, type EntityEquippableComponent, type EntityInventoryComponent } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand(['假人资源回收','假人背包清空','假人爆金币'], ({entity,isEntity,sim})=>{
@@ -12,7 +12,7 @@ commandManager.registerCommand(['假人资源回收','假人背包清空','假�
     const SimPlayer:SimulatedPlayer = sim ?? getSimPlayer.fromView(entity)
     if(!SimPlayer)return
 
-    const equip = <EntityEquippableComponent><unknown>SimPlayer.getComponent("minecraft:equippable")
+    const equip = SimPlayer.getComponent("minecraft:equippable")
 
     // emmm你这变量名
     const { location:l, dimension:d } = entity
@@ -29,7 +29,7 @@ commandManager.registerCommand(['假人资源回收','假人背包清空','假�
         equip.setEquipment(<EquipmentSlot>i, null) //undefined? new ItemStack('air')?
     }
 
-    const { container:s } =  <EntityInventoryComponent><unknown>SimPlayer.getComponent("minecraft:inventory")
+    const { container:s } =  SimPlayer.getComponent("minecraft:inventory")
 
     for (
         let i = s.size;

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -1,4 +1,4 @@
-import { Player, system, world } from '@minecraft/server'
+import { system, world } from '@minecraft/server'
 import SIGN, {
     BEHAVIOR,
     BEHAVIOR_LIST,
@@ -24,7 +24,7 @@ world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
     const {player,target} = e
     if(!player || player.typeId!=='minecraft:player')return
     if(!target || !simulatedPlayerManager.has(target))return// world.sendMessage('meow~ target');
-    const SimPlayer = <SimulatedPlayer><unknown>target // what's unknow?
+    const SimPlayer = <SimulatedPlayer>target // what's unknow?
     if(!SimPlayer)return
     e.cancel=true
 
@@ -36,8 +36,7 @@ world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
             mng.button((SimPlayer.hasTag(signKey)?'§l§e':'§l§1') + SIGN_ZH[SIGN[signKey]])
             // world.sendMessage('#tag=>'+signKey);
         }
-        // @ts-ignore
-        mng.show(<Player>player).then((response) => {
+        mng.show(player).then((response) => {
             const tag = SIGN_TAG_LIST[response.selection]
             SimPlayer.hasTag(tag)?SimPlayer.removeTag(tag):SimPlayer.addTag(tag)
         },()=>0).catch(()=>0)
@@ -51,8 +50,7 @@ world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
         for (const behavior of BEHAVIOR_LIST)
             mng.button((SimPlayer.hasTag(behavior)?'§l§e':'§l§1') + BEHAVIOR_ZH[BEHAVIOR[behavior]])
 
-        // @ts-ignore
-        mng.show(<Player>player).then((response) => {
+        mng.show(player).then((response) => {
             const behavior = BEHAVIOR_LIST[response.selection]
             exeBehavior(behavior)(SimPlayer,player)
         },()=>0).catch(()=>0)

--- a/src/features/task.ts
+++ b/src/features/task.ts
@@ -6,19 +6,17 @@ import type { EntityHealthComponent, Vector3 } from '@minecraft/server'
 import { system, world } from '@minecraft/server'
 import { getEntitiesNear, getPlayerNear } from '@/core/queries/Util'
 
-// @ts-ignore
 const simulatedPlayerStates : ({ "str-SimPlayer.id": { o: Vector3 }}) = {}
 
 const Vector_subtract = ({x,y,z}:Vector3, {x:u,y:v,z:w}:Vector3)=>({x:x-u,y:y-v,z:z-w})
 // behavior
 function AUTO_BEHAVIOR(){
 
-    const AllPlayerCount = world.getAllPlayers().length
     for (const [pid, simulatedPlayer] of simulatedPlayerManager.simulatedPlayers) {
         // world.sendMessage(SimPlayer.nameTag)
         //判假人是否存活
         //瞎糊乱改接口名--2023-07-21-02：02
-        if((<EntityHealthComponent>simulatedPlayer.getComponent('minecraft:health')).currentValue<=0){
+        if((simulatedPlayer.getComponent('minecraft:health')).currentValue<=0){
             if(simulatedPlayer.hasTag(SIGN.AUTO_RESPAWN_SIGN))simulatedPlayer.respawn()
                 
             continue
@@ -72,7 +70,6 @@ function AUTO_BEHAVIOR(){
     }
 
     // /gamerule playerssleepingpercentage 50%
-    // SimulatedPlayerCount && world.getDimension('minecraft:overworld').runCommand('gamerule playerssleepingpercentage '+Math.floor(100*SimulatedPlayerCount/AllPlayerCount))
 }
 
 system.runInterval(AUTO_BEHAVIOR,20)


### PR DESCRIPTION
由于依赖版本已成功统一，很多一次和二次断言都不再需要