### PR TITLE
perf(core/command/command-parser): 避免重复编译正则表达式

### DIFF
--- a/src/core/command/command-parser.ts
+++ b/src/core/command/command-parser.ts
@@ -1,7 +1,8 @@
 import { InvalidInputError } from "./errors";
 
+const regex = /"([^"]*)"|'([^']*)'|(\S+)/g; // 正则匹配所有单词或引号内的文本
+
 export function parseCommandString(input: string): { prefix: string; args: string[]; } {
-    const regex = /"([^"]*)"|'([^']*)'|(\S+)/g; // 正则匹配所有单词或引号内的文本
     const parts = [];
     let match: RegExpMatchArray | null;
 


### PR DESCRIPTION
常量从函数内部提升到模块作用域，复用正则表达式实例