### PR TITLE
fix(tps): 修复无法正确在玩家加入时自动启动 tps

### DIFF
--- a/src/features/commands/handlers/tps/indicator.ts
+++ b/src/features/commands/handlers/tps/indicator.ts
@@ -32,8 +32,6 @@ commandManager.registerCommand('tps关', ({ entity }) => {
 });
 
 const checkIfRequireTPS = (): boolean => {
-    console.log(world.getPlayers({ tags: [TPS_TAG] }).length);
-    
     return world.getPlayers({ tags: [TPS_TAG] }).length > 0;
 };
 

--- a/src/features/commands/handlers/tps/indicator.ts
+++ b/src/features/commands/handlers/tps/indicator.ts
@@ -5,7 +5,7 @@ import { playerReady } from "@/features/events/player-ready";
 
 const TPS_TAG = 'tps';
 
-const EVENTS: { subscribe: (...args: any) => void; }[] = [world.afterEvents.playerJoin, world.afterEvents.playerLeave, playerReady];
+const EVENTS: { subscribe: (...args: any) => void; }[] = [world.afterEvents.playerSpawn, world.afterEvents.playerLeave, playerReady];
 
 const tpsMonitor = new TPSMonitor();
 
@@ -32,6 +32,8 @@ commandManager.registerCommand('tps关', ({ entity }) => {
 });
 
 const checkIfRequireTPS = (): boolean => {
+    console.log(world.getPlayers({ tags: [TPS_TAG] }).length);
+    
     return world.getPlayers({ tags: [TPS_TAG] }).length > 0;
 };
 


### PR DESCRIPTION
延迟自动开关至事件 `playerSpawn`，确保正确捕获需要 tps 的玩家