### PR TITLE
refactor(core): 移动部分类的实例化过程到 `core/` 中

### DIFF
--- a/src/core/gametest/manager.ts
+++ b/src/core/gametest/manager.ts
@@ -3,7 +3,7 @@ import { register, type Test } from "@minecraft/server-gametest";
 
 const overworld = world.getDimension('overworld');
 
-export class GameTestManager {
+class GameTestManager {
     private readonly maxTicks = 20 * 60 * 60 * 24 * 365;
     private _testLocation: Vector3 | undefined;
     private _test: Test | undefined;
@@ -64,3 +64,5 @@ export class GameTestManager {
         });
     }
 }
+
+export const gameTestManager = new GameTestManager();

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -5,7 +5,7 @@ import { SimulatedPlayerNotFoundError, NotReadyError } from "./errors";
 import type { Entity } from "@minecraft/server";
 import type { AddSimulatedPlayerOptions, SpawnSimulatedPlayerOptions } from "./types";
 
-export class SimulatedPlayerManager {
+class SimulatedPlayerManager {
     private readonly initialSigns = [
         SIGN.YUME_SIM_SIGN,
         SIGN.AUTO_RESPAWN_SIGN
@@ -128,3 +128,5 @@ export class SimulatedPlayerManager {
         return this.pidManager.reset();
     }
 }
+
+export const simulatedPlayerManager = new SimulatedPlayerManager();

--- a/src/features/commands/handlers/behaviors/break-block.ts
+++ b/src/features/commands/handlers/behaviors/break-block.ts
@@ -4,7 +4,7 @@ import { Command, commandManager } from '@/core/command';
 import { getSimPlayer } from '@/core/queries/Util';
 import { world, system } from "@minecraft/server";
 import SIGN from "@/constants/YumeSignEnum";
-import { testManager } from '@/main';
+import { gameTestManager } from '@/core/gametest/manager';
 
 const breakBlockCommand = new Command();
 breakBlockCommand.register(({ args }) => args.length === 0, ({ entity, isEntity }) => {
@@ -31,7 +31,7 @@ const breaks = () =>
         if (!block) return;
 
         if (block.isValid && !block.isLiquid && !block.isAir) {
-            man.breakBlock(testManager.test.relativeBlockLocation(block));
+            man.breakBlock(gameTestManager.test.relativeBlockLocation(block));
         }
     });
 

--- a/src/features/commands/handlers/lifecycle/disconnect.ts
+++ b/src/features/commands/handlers/lifecycle/disconnect.ts
@@ -1,7 +1,7 @@
 import { commandManager, getLocationFromEntityLike } from "@/core/command";
 import type { PID } from "@/core/pid";
 import { getSimPlayer } from "@/core/queries/Util";
-import { simulatedPlayerManager } from "@/main";
+import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand(['假人销毁','假人移除','假人清除'], ({entity,isEntity,args:[simIndex],sim}) => {

--- a/src/features/commands/handlers/lifecycle/respawn.ts
+++ b/src/features/commands/handlers/lifecycle/respawn.ts
@@ -1,7 +1,7 @@
 import { commandManager } from "@/core/command";
 import type { PID } from "@/core/pid";
 import { getSimPlayer } from "@/core/queries/Util";
-import { simulatedPlayerManager } from "@/main";
+import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'],

--- a/src/features/commands/handlers/lifecycle/spawn.ts
+++ b/src/features/commands/handlers/lifecycle/spawn.ts
@@ -1,4 +1,4 @@
-import { simulatedPlayerManager } from '@/main';
+import { simulatedPlayerManager } from '@/core/simulated-player';
 import { type CommandInfo, commandManager, Command } from '@/core/command'
 import { Dimension, LocationOutOfWorldBoundariesError, Vector3, world, type Player } from '@minecraft/server'
 import {parseCoordinates} from "@/utils/parse-coordinates";

--- a/src/features/commands/handlers/meta/list-simulated-players.ts
+++ b/src/features/commands/handlers/meta/list-simulated-players.ts
@@ -1,5 +1,5 @@
 import { commandManager } from "@/core/command";
-import { simulatedPlayerManager } from "@/main";
+import { simulatedPlayerManager } from '@/core/simulated-player';
 import { world } from "@minecraft/server";
 
 commandManager.registerCommand('假人列表', ({entity}) => {

--- a/src/features/commands/handlers/meta/location.ts
+++ b/src/features/commands/handlers/meta/location.ts
@@ -2,7 +2,7 @@ import { dimensionMap } from "@/constants/dimensions";
 import { commandManager } from "@/core/command";
 import type { PID } from "@/core/pid";
 import { getSimPlayer } from "@/core/queries/Util";
-import { simulatedPlayerManager } from "@/main";
+import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.registerCommand(['假人位置', '假人坐标'], ({ entity, isEntity, args: [simIndex] }) => {

--- a/src/features/commands/handlers/meta/setting.ts
+++ b/src/features/commands/handlers/meta/setting.ts
@@ -1,5 +1,5 @@
 import { commandManager } from '@/core/command'
-import { simulatedPlayerManager } from '@/main';
+import { simulatedPlayerManager } from '@/core/simulated-player';
 
 commandManager.registerCommand(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ entity }) => {
     const PID = simulatedPlayerManager.resetPID()

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -9,7 +9,7 @@ import SIGN, {
 } from '@/constants/YumeSignEnum'
 import { ActionFormData } from '@minecraft/server-ui'
 import { SimulatedPlayer } from '@minecraft/server-gametest'
-import { simulatedPlayerManager } from '@/main'
+import { simulatedPlayerManager } from '@/core/simulated-player';
 
 // world.afterEvents.entityHitEntity.subscribe(({damagingEntity,hitEntity})=>{
 //     if(!damagingEntity || !hitEntity)return;

--- a/src/features/killedBySimPlayer.ts
+++ b/src/features/killedBySimPlayer.ts
@@ -1,5 +1,5 @@
 import { EntityDamageCause, world, type Player } from '@minecraft/server';
-import { simulatedPlayerManager } from '@/main';
+import { simulatedPlayerManager } from '@/core/simulated-player';
 
 world.afterEvents.entityDie.subscribe(({ damageSource: { cause, damagingEntity }, deadEntity }) => {
     if (cause !== EntityDamageCause.entityAttack) return;

--- a/src/features/task.ts
+++ b/src/features/task.ts
@@ -1,10 +1,11 @@
 //@ts-nocheck
 import type { SimulatedPlayer } from '@minecraft/server-gametest'
-import {simulatedPlayerManager, testManager} from '@/main'
 import SIGN from '@/constants/YumeSignEnum'
 import type { EntityHealthComponent, Vector3 } from '@minecraft/server'
 import { system, world } from '@minecraft/server'
 import { getEntitiesNear, getPlayerNear } from '@/core/queries/Util'
+import { simulatedPlayerManager } from '@/core/simulated-player';
+import { gameTestManager } from '@/core/gametest/manager';
 
 const simulatedPlayerStates : ({ "str-SimPlayer.id": { o: Vector3 }}) = {}
 
@@ -47,7 +48,7 @@ function AUTO_BEHAVIOR(){
             const r = (x:number,_x:number,v:number)=>x-_x>v||x-_x<-v
             const r3 = (o:Vector3,_o:Vector3,v:number)=>o.x-_o.x>v||o.x-_o.x<-v || o.y-_o.y>v||o.y-_o.y<-v || o.z-_o.z>v||o.z-_o.z<-v
             // const fix = (o:Vector3)=>({x:o.x-30000000+1,y:o.y,z:o.z-3})
-            const fix = (location:Vector3)=>Vector_subtract(location, testManager.testLocation)
+            const fix = (location:Vector3)=>Vector_subtract(location, gameTestManager.testLocation)
             // && r3(SimulatedPlayerStates[SimPlayer]["o"],SimPlayer.location,16)
             if(entities.length>0 ){
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,23 +3,21 @@ import { world } from '@minecraft/server'
 import '@/features'
 
 import {playerReady} from "@/features/events/player-ready";
-import { SimulatedPlayerManager } from '@/core/simulated-player';
-import { GameTestManager } from '@/core/gametest/manager';
+import { simulatedPlayerManager } from '@/core/simulated-player';
+import { gameTestManager } from '@/core/gametest/manager';
 
-export const simulatedPlayerManager=new SimulatedPlayerManager();
 
-export const testManager = new GameTestManager()
-testManager.ready.then(test => {
+gameTestManager.ready.then(test => {
     simulatedPlayerManager.test = test;
 });
-testManager.registerTest();
+gameTestManager.registerTest();
 
 world.afterEvents.worldLoad.subscribe(() => {
     simulatedPlayerManager.initialize();
-    testManager.initialize();
+    gameTestManager.initialize();
 });
 
 playerReady.subscribe(async () => {
-    await testManager.ready;
+    await gameTestManager.ready;
     world.sendMessage('[模拟玩家] 初始化完成，输入“假人创建”或“ffpp”');
 });


### PR DESCRIPTION
隐式单例，导出实例，不导出类

以去除双向依赖