### PR TITLE
build(tsconfig): 改输出路径为 `./scripts/`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,7 +55,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./scripts_yeah/",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./scripts/",                                   /* Specify an output folder for all emitted files. */
     "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
现在无需 tsc 的中间态