### PR TITLE
refactor(command): 简化 `manager` 方法名

### DIFF
--- a/src/constants/YumeSignEnum.ts
+++ b/src/constants/YumeSignEnum.ts
@@ -67,9 +67,9 @@ export const BEHAVIOR_FUNCTION = {
     useItemInSlot : (sim:SimulatedPlayer&Player)=>sim.useItemInSlot(sim.selectedSlotIndex),
     stopUsingItem : (sim:SimulatedPlayer)=>sim.stopUsingItem(),
     interact : (sim:SimulatedPlayer)=>sim.interact(),
-    swapMainhandItem : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人主手物品交换',{entity:player,sim}),
-    swapInventory : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人背包交换',{entity:player,sim}),
-    swapEquipment : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人装备交换',{entity:player,sim}),
+    swapMainhandItem : (sim:SimulatedPlayer,player:Player)=>commandManager.run('假人主手物品交换',{entity:player,sim}),
+    swapInventory : (sim:SimulatedPlayer,player:Player)=>commandManager.run('假人背包交换',{entity:player,sim}),
+    swapEquipment : (sim:SimulatedPlayer,player:Player)=>commandManager.run('假人装备交换',{entity:player,sim}),
     rename: async (sim: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
         modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', sim.nameTag);
@@ -79,8 +79,8 @@ export const BEHAVIOR_FUNCTION = {
         sim.nameTag = <string>formValues[0];
         // commandManager.executeCommand('假人改名', [name], { entity: player, sim });
     },
-    recycle : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人资源回收',{entity:player,sim}), // item and exp
-    disconnect : (sim:SimulatedPlayer)=>commandManager.execute('假人销毁',{sim}),
+    recycle : (sim:SimulatedPlayer,player:Player)=>commandManager.run('假人资源回收',{entity:player,sim}), // item and exp
+    disconnect : (sim:SimulatedPlayer)=>commandManager.run('假人销毁',{sim}),
 }
 export const exeBehavior = (behavior: string) => BEHAVIOR[behavior] && BEHAVIOR_FUNCTION[behavior]
 

--- a/src/features/commands/handlers/behaviors/behaviors.ts
+++ b/src/features/commands/handlers/behaviors/behaviors.ts
@@ -73,7 +73,7 @@ const behaviorPrefix = '假人';
 
 const registerBehaviorCommands = () => {
     behaviorCommandConfigs.forEach(behaviorCommand => {
-        commandManager.registerCommand(`${behaviorPrefix}${behaviorCommand.behavior}`, ({ entity }) => {
+        commandManager.add(`${behaviorPrefix}${behaviorCommand.behavior}`, ({ entity }) => {
             if (!entity) return;
             const simulatedPlayer = getSimPlayer.fromView(entity);
             if (!simulatedPlayer) return;

--- a/src/features/commands/handlers/behaviors/break-block.ts
+++ b/src/features/commands/handlers/behaviors/break-block.ts
@@ -21,7 +21,7 @@ breakBlockCommand.register(({ args }) => args.length === 0, ({ entity, isEntity 
 
     SimPlayer.addTag(SIGN.AUTO_BREAKBLOCK_SIGN);
 });
-commandManager.registerCommand(['假人挖掘', '假人摧毁'], breakBlockCommand);
+commandManager.add(['假人挖掘', '假人摧毁'], breakBlockCommand);
 
 // task
 const breaks = () =>

--- a/src/features/commands/handlers/inventory/equipment-swap.ts
+++ b/src/features/commands/handlers/inventory/equipment-swap.ts
@@ -3,7 +3,7 @@ import { getSimPlayer } from "@/core/queries";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人装备交换','假人交换装备'], ({entity,isEntity,sim}) => {
+commandManager.add(['假人装备交换','假人交换装备'], ({entity,isEntity,sim}) => {
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
     if(!isEntity && !sim)return
 

--- a/src/features/commands/handlers/inventory/inventory-swap.ts
+++ b/src/features/commands/handlers/inventory/inventory-swap.ts
@@ -2,7 +2,7 @@ import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人背包交换','假人交换背包'], ({entity,isEntity,sim}) => {
+commandManager.add(['假人背包交换','假人交换背包'], ({entity,isEntity,sim}) => {
     if(!isEntity && !sim)return
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
     if(!SimPlayer)return

--- a/src/features/commands/handlers/inventory/mainhand-swap.ts
+++ b/src/features/commands/handlers/inventory/mainhand-swap.ts
@@ -3,7 +3,7 @@ import { getSimPlayer } from "@/core/queries";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand('假人主手物品交换', ({entity,sim}) => {
+commandManager.add('假人主手物品交换', ({entity,sim}) => {
 
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
 

--- a/src/features/commands/handlers/inventory/offhand-swap.ts
+++ b/src/features/commands/handlers/inventory/offhand-swap.ts
@@ -3,7 +3,7 @@ import { getSimPlayer } from "@/core/queries";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand('假人副手物品交换', ({entity,sim}) => {
+commandManager.add('假人副手物品交换', ({entity,sim}) => {
 
     const SimPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(entity)
 

--- a/src/features/commands/handlers/inventory/recycle.ts
+++ b/src/features/commands/handlers/inventory/recycle.ts
@@ -3,7 +3,7 @@ import { getSimPlayer } from "@/core/queries";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人资源回收','假人背包清空','假人爆金币'], ({entity,isEntity,sim})=>{
+commandManager.add(['假人资源回收','假人背包清空','假人爆金币'], ({entity,isEntity,sim})=>{
     if(!isEntity && !sim) {
         console.error('error not isEntity')
         return

--- a/src/features/commands/handlers/lifecycle/disconnect.ts
+++ b/src/features/commands/handlers/lifecycle/disconnect.ts
@@ -4,7 +4,7 @@ import { getSimPlayer } from "@/core/queries";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人销毁','假人移除','假人清除'], ({entity,isEntity,args:[simIndex],sim}) => {
+commandManager.add(['假人销毁','假人移除','假人清除'], ({entity,isEntity,args:[simIndex],sim}) => {
     if(sim)return simulatedPlayerManager.remove(sim);
 
     if(!isEntity) {
@@ -15,7 +15,7 @@ commandManager.registerCommand(['假人销毁','假人移除','假人清除'], (
         const SimPlayer:SimulatedPlayer = getSimPlayer.fromView(entity)
         if(!SimPlayer)return entity.sendMessage("§e§l-面前不存在模拟玩家")
 
-        commandManager.executeCommand('假人背包清空', [], { entity, isEntity, sim: SimPlayer ,location:getLocationFromEntityLike(entity)})
+        commandManager.run('假人背包清空', [], { entity, isEntity, sim: SimPlayer ,location:getLocationFromEntityLike(entity)})
         entity.sendMessage("§e§l-拜拜了您内")
         simulatedPlayerManager.remove(SimPlayer)
     }
@@ -28,7 +28,7 @@ commandManager.registerCommand(['假人销毁','假人移除','假人清除'], (
 
         if(!SimPlayer)return entity.sendMessage("§e§l-不存在模拟玩家"+index)
 
-        commandManager.executeCommand('假人背包清空', [], { entity, isEntity, sim: SimPlayer ,location:getLocationFromEntityLike(entity)})
+        commandManager.run('假人背包清空', [], { entity, isEntity, sim: SimPlayer ,location:getLocationFromEntityLike(entity)})
         entity.sendMessage("§e§l-拜拜了您内")
         simulatedPlayerManager.remove(SimPlayer)
     }

--- a/src/features/commands/handlers/lifecycle/respawn.ts
+++ b/src/features/commands/handlers/lifecycle/respawn.ts
@@ -4,7 +4,7 @@ import { getSimPlayer } from "@/core/queries";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'],
+commandManager.add(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'],
     ({ entity, isEntity, args: [simIndex] }) => {
 
     if (!isEntity && simIndex === undefined) {

--- a/src/features/commands/handlers/lifecycle/spawn.ts
+++ b/src/features/commands/handlers/lifecycle/spawn.ts
@@ -94,7 +94,7 @@ chatSpawnCommand.register(({ args, entity }) => {
     entity?.sendMessage(`[模拟玩家] 命令错误，期待3个坐标数字(x y z)或1个名称字符串("名称")，得到个数为${args.length}。带空格名称需用引号包裹`);
 });
 
-commandManager.registerCommand(['假人生成', '假人创建', 'ffpp'], chatSpawnCommand);
+commandManager.add(['假人生成', '假人创建', 'ffpp'], chatSpawnCommand);
 
 // world.afterEvents.chatSend.subscribe(({message, sender})=>{
 //     const cmdArgs = CommandRegistry.parse(message)

--- a/src/features/commands/handlers/meta/help.ts
+++ b/src/features/commands/handlers/meta/help.ts
@@ -101,11 +101,11 @@ helpCommand.register(({ args, isEntity }) => args.length > 0 && isEntity, ({ arg
             entity.sendMessage("对不起，没有这种事情，做不到" + (Math.random() < 0.233 ? "给钱也做不到" : "真做不到"));
 });
 
-commandManager.registerCommand(['假人帮助', '假人help'], helpCommand)
+commandManager.add(['假人帮助', '假人help'], helpCommand)
 
 const githubCommand = new Command();
 githubCommand.register(({ entity }) => entity.sendMessage('§rhttps://github.com/xBoyMinemc 能不能扫上随缘\u000a' + (Math.random() > 0.5 ? qrcodeTextGithub : qrcodeTextRoll)));
-commandManager.registerCommand('假人github', githubCommand);
+commandManager.add('假人github', githubCommand);
 
 
 // console.error('[假人]内置插件help加载成功')

--- a/src/features/commands/handlers/meta/list-commands.ts
+++ b/src/features/commands/handlers/meta/list-commands.ts
@@ -1,5 +1,5 @@
 import { commandManager } from "@/core/command";
 
-commandManager.registerCommand(['showshowway', '假人命令列表'], ({ entity }) => {
-    entity?.sendMessage(commandManager.listRegisteredPrefixes().join('\n'));
+commandManager.add(['showshowway', '假人命令列表'], ({ entity }) => {
+    entity?.sendMessage(commandManager.list().join('\n'));
 });

--- a/src/features/commands/handlers/meta/list-simulated-players.ts
+++ b/src/features/commands/handlers/meta/list-simulated-players.ts
@@ -2,7 +2,7 @@ import { commandManager } from "@/core/command";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import { world } from "@minecraft/server";
 
-commandManager.registerCommand('假人列表', ({entity}) => {
+commandManager.add('假人列表', ({entity}) => {
     let target = entity ?? world;
     if (simulatedPlayerManager.simulatedPlayers.size === 0) return target.sendMessage('列表空的');
     for (const [index, simulatedPlayer] of simulatedPlayerManager.simulatedPlayers) {

--- a/src/features/commands/handlers/meta/location.ts
+++ b/src/features/commands/handlers/meta/location.ts
@@ -5,7 +5,7 @@ import { getSimPlayer } from "@/core/queries";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人位置', '假人坐标'], ({ entity, isEntity, args: [simIndex] }) => {
+commandManager.add(['假人位置', '假人坐标'], ({ entity, isEntity, args: [simIndex] }) => {
     if (!isEntity && simIndex === undefined) {
         console.error('error not isEntity');
         return;

--- a/src/features/commands/handlers/meta/rename.ts
+++ b/src/features/commands/handlers/meta/rename.ts
@@ -2,7 +2,7 @@ import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.registerCommand(['假人改名', '假人重命名', '假人换名'], ({entity,isEntity,args:[newName]}) => {
+commandManager.add(['假人改名', '假人重命名', '假人换名'], ({entity,isEntity,args:[newName]}) => {
     if(!isEntity) {
         console.error('error not isEntity')
         return

--- a/src/features/commands/handlers/meta/setting.ts
+++ b/src/features/commands/handlers/meta/setting.ts
@@ -1,7 +1,7 @@
 import { commandManager } from '@/core/command'
 import { simulatedPlayerManager } from '@/core/simulated-player';
 
-commandManager.registerCommand(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ entity }) => {
+commandManager.add(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ entity }) => {
     const PID = simulatedPlayerManager.resetPID()
     entity?.sendMessage('重置成功，重置前为'+PID)
 

--- a/src/features/commands/handlers/meta/time.ts
+++ b/src/features/commands/handlers/meta/time.ts
@@ -1,7 +1,7 @@
 import { commandManager } from "@/core/command";
 import { TicksPerSecond } from "@minecraft/server";
 
-commandManager.registerCommand(['假人时区', '假人时间'], ({entity}) => {
+commandManager.add(['假人时区', '假人时间'], ({entity}) => {
     // entity.sendMessage(''+Intl.DateTimeFormat().resolvedOptions().timeZone)
 
     const now = new Date()

--- a/src/features/commands/handlers/tps/indicator.ts
+++ b/src/features/commands/handlers/tps/indicator.ts
@@ -15,7 +15,7 @@ tpsMonitor.tpsUpdate.subscribe(({ tps }) => {
     });
 });
 
-commandManager.registerCommand('tps开', ({ entity }) => {
+commandManager.add('tps开', ({ entity }) => {
     if (!entity) return;
 
     entity.addTag(TPS_TAG);
@@ -23,7 +23,7 @@ commandManager.registerCommand('tps开', ({ entity }) => {
     autoSwitchTPS();
 });
 
-commandManager.registerCommand('tps关', ({ entity }) => {
+commandManager.add('tps关', ({ entity }) => {
     if (!entity) return;
 
     entity.removeTag(TPS_TAG);

--- a/src/features/commands/triggers/chat-send.ts
+++ b/src/features/commands/triggers/chat-send.ts
@@ -5,7 +5,7 @@ import { Messages } from "@/constants";
 world.beforeEvents.chatSend.subscribe(({message, sender}) => {
     system.run(() => {
         try {
-            commandManager.execute(message, {
+            commandManager.run(message, {
                 entity: sender,
                 isEntity: true,
                 location: getLocationFromEntityLike(sender)

--- a/src/features/commands/triggers/script-event.ts
+++ b/src/features/commands/triggers/script-event.ts
@@ -72,7 +72,7 @@ system.afterEvents.scriptEventReceive.subscribe(e => {
     const commandString = parseScriptEventString(e);
 
     try {
-        commandManager.execute(commandString, commandInfoNoArgs);
+        commandManager.run(commandString, commandInfoNoArgs);
     } catch (e) {
         console.error(e);
         if (e instanceof CommandNotFoundError)


### PR DESCRIPTION
- registerCommand => add
- unregisterCommand => remove
- executeCommand, execute => run (reload)
- listRegisteredPrefixes => list

同时也能与其他几个 core 模块的命名相统一