### PR TITLE
refactor(tps): 修改 `start` 和 `stop` 方法中的运行状态检查逻辑

### DIFF
--- a/src/core/tps/monitor.ts
+++ b/src/core/tps/monitor.ts
@@ -11,14 +11,14 @@ export class TPSMonitor {
     readonly tpsUpdate = new EventSignal<TPSUpdateEvent>();
 
     start(): boolean {
-        if (this.runId) return false;
+        if (this.isRunning) return false;
 
         this.runId = system.runInterval(() => this.update());
         return true;
     }
 
     stop(): boolean {
-        if (!this.runId) return false;
+        if (!this.isRunning) return false;
 
         system.clearRun(this.runId);
         this.runId = undefined;


### PR DESCRIPTION
使用 `isRunning` 属性，规避可能的 `runId=0`