### PR TITLE
refactor(simulated-player-manager): `has` 方法自动类型收窄

### DIFF
--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -87,7 +87,7 @@ class SimulatedPlayerManager {
 
     has(pid: PID): boolean;
     has(id: string): boolean;
-    has(simulatedPlayer: Entity): boolean;
+    has(simulatedPlayer: Entity): simulatedPlayer is SimulatedPlayer;
     has(target: PID | string | Entity): boolean {
         if (typeof target === 'number')
             return this._pidToSimulatedPlayer.has(target);

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -8,7 +8,6 @@ import { SIGN,
     SIGN_ZH
 } from '@/constants'
 import { ActionFormData } from '@minecraft/server-ui'
-import { SimulatedPlayer } from '@minecraft/server-gametest'
 import { simulatedPlayerManager } from '@/core/simulated-player';
 
 // world.afterEvents.entityHitEntity.subscribe(({damagingEntity,hitEntity})=>{
@@ -24,7 +23,7 @@ world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
     const {player,target} = e
     if(!player || player.typeId!=='minecraft:player')return
     if(!target || !simulatedPlayerManager.has(target))return// world.sendMessage('meow~ target');
-    const simulatedPLayer = <SimulatedPlayer>target // what's unknow?
+    const simulatedPLayer = target // what's unknow?
     if(!simulatedPLayer)return
     e.cancel=true
 


### PR DESCRIPTION
省去二次断言的冗余