### PR TITLE
refactor(simulated-player-manager): `has` 方法的重载形参名改为 `entity`

### DIFF
--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -87,7 +87,7 @@ class SimulatedPlayerManager {
 
     has(pid: PID): boolean;
     has(id: string): boolean;
-    has(simulatedPlayer: Entity): simulatedPlayer is SimulatedPlayer;
+    has(entity: Entity): entity is SimulatedPlayer;
     has(target: PID | string | Entity): boolean {
         if (typeof target === 'number')
             return this._pidToSimulatedPlayer.has(target);


### PR DESCRIPTION
与其作用和类型相匹配