### PR TITLE
refactor(command): `command-parser` 使用 `matchAll` 替代 `regex.exec`

### DIFF
--- a/src/core/command/command-parser.ts
+++ b/src/core/command/command-parser.ts
@@ -17,9 +17,9 @@ const regex = /"([^"]*)"|'([^']*)'|(\S+)/g; // 正则匹配所有单词或引号
  */
 export function parseCommandString(input: string): { prefix: string; args: string[]; } {
     const parts = [];
-    let match: RegExpMatchArray | null;
+    const iterator = input.matchAll(regex);
 
-    while (match = regex.exec(input)) {
+    for (const match of iterator) {
         // 将捕获组中的内容添加到结果数组中
         parts.push(match[1] ?? match[2] ?? match[3]);
     }


### PR DESCRIPTION
提升可读性 同时避免可能的 `exec` 未重置 `lastIndex`