### PR TITLE
refactor(gui): 代码清理和重命名

### DIFF
--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -20,26 +20,26 @@ import { type SimulatedPlayer, LookDuration } from '@minecraft/server-gametest';
 // })
 
 const BEHAVIOR_HANDLERS = {
-    lookAtEntity: (sim: SimulatedPlayer, player: Player) => sim.lookAtEntity(player, LookDuration.Instant),
-    teleport: (sim: SimulatedPlayer, player: Player) => sim.teleport(player.location),
-    useAndStopUsingItem: (sim: SimulatedPlayer & Player) => sim.useItemInSlot(sim.selectedSlotIndex) && sim.stopUsingItem(),
-    useItemInSlot: (sim: SimulatedPlayer & Player) => sim.useItemInSlot(sim.selectedSlotIndex),
-    stopUsingItem: (sim: SimulatedPlayer) => sim.stopUsingItem(),
-    interact: (sim: SimulatedPlayer) => sim.interact(),
-    swapMainhandItem: (sim: SimulatedPlayer, player: Player) => commandManager.run('假人主手物品交换', { player, simulatedPlayer: sim }),
-    swapInventory: (sim: SimulatedPlayer, player: Player) => commandManager.run('假人背包交换', { player, simulatedPlayer: sim }),
-    swapEquipment: (sim: SimulatedPlayer, player: Player) => commandManager.run('假人装备交换', { player, simulatedPlayer: sim }),
-    rename: async (sim: SimulatedPlayer, player: Player) => {
+    lookAtEntity: (simulatedPlayer: SimulatedPlayer, player: Player) => simulatedPlayer.lookAtEntity(player, LookDuration.Instant),
+    teleport: (simulatedPlayer: SimulatedPlayer, player: Player) => simulatedPlayer.teleport(player.location),
+    useAndStopUsingItem: (simulatedPlayer: SimulatedPlayer & Player) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex) && simulatedPlayer.stopUsingItem(),
+    useItemInSlot: (simulatedPlayer: SimulatedPlayer & Player) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex),
+    stopUsingItem: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.stopUsingItem(),
+    interact: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.interact(),
+    swapMainhandItem: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人主手物品交换', { player, simulatedPlayer }),
+    swapInventory: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人背包交换', { player, simulatedPlayer }),
+    swapEquipment: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人装备交换', { player, simulatedPlayer }),
+    rename: async (simulatedPlayer: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
-        modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', sim.nameTag);
+        modalForm.textField(`由 "${simulatedPlayer.nameTag}" 改为：`, '输入新名称', simulatedPlayer.nameTag);
         const { canceled, formValues } = await modalForm.show(player);
         if (canceled) return;
 
-        sim.nameTag = <string>formValues[0];
-        // commandManager.executeCommand('假人改名', [name], { entity: player, sim });
+        simulatedPlayer.nameTag = <string>formValues[0];
+        // commandManager.executeCommand('假人改名', [name], { entity: player, simulatedPlayer });
     },
-    recycle: (sim: SimulatedPlayer, player: Player) => commandManager.run('假人资源回收', { player, simulatedPlayer: sim }), // item and exp
-    disconnect: (sim: SimulatedPlayer) => commandManager.run('假人销毁', { simulatedPlayer: sim }),
+    recycle: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人资源回收', { player, simulatedPlayer }), // item and exp
+    disconnect: (simulatedPlayer: SimulatedPlayer) => commandManager.run('假人销毁', { simulatedPlayer }),
 };
 
 export const exeBehavior = (behavior: string) => BEHAVIOR[behavior] && BEHAVIOR_HANDLERS[behavior];

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -22,8 +22,8 @@ import { type SimulatedPlayer, LookDuration } from '@minecraft/server-gametest';
 const BEHAVIOR_HANDLERS = {
     lookAtEntity: (simulatedPlayer: SimulatedPlayer, player: Player) => simulatedPlayer.lookAtEntity(player, LookDuration.Instant),
     teleport: (simulatedPlayer: SimulatedPlayer, player: Player) => simulatedPlayer.teleport(player.location),
-    useAndStopUsingItem: (simulatedPlayer: SimulatedPlayer & Player) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex) && simulatedPlayer.stopUsingItem(),
-    useItemInSlot: (simulatedPlayer: SimulatedPlayer & Player) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex),
+    useAndStopUsingItem: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex) && simulatedPlayer.stopUsingItem(),
+    useItemInSlot: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex),
     stopUsingItem: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.stopUsingItem(),
     interact: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.interact(),
     swapMainhandItem: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人主手物品交换', { player, simulatedPlayer }),

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -11,14 +11,6 @@ import { simulatedPlayerManager } from '@/core/simulated-player';
 import { commandManager } from '@/core/command';
 import { type SimulatedPlayer, LookDuration } from '@minecraft/server-gametest';
 
-// world.afterEvents.entityHitEntity.subscribe(({damagingEntity,hitEntity})=>{
-//     if(!damagingEntity || !hitEntity)return;
-//     if(!hitEntity.hasTag(SIGN.YUME_SIM_SIGN))return;
-//     world.sendMessage(''+damagingEntity.typeId+' '+(hitEntity.typeId))
-//     new ActionFormData().body('#x#').button('喵？')
-//         .show(damagingEntity)
-// })
-
 const BEHAVIOR_HANDLERS = {
     lookAtEntity: (simulatedPlayer: SimulatedPlayer, player: Player) => simulatedPlayer.lookAtEntity(player, LookDuration.Instant),
     teleport: (simulatedPlayer: SimulatedPlayer, player: Player) => simulatedPlayer.teleport(player.location),

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -46,11 +46,9 @@ export const exeBehavior = (behavior: string) => BEHAVIOR[behavior] && BEHAVIOR_
 
 
 world.beforeEvents.playerInteractWithEntity.subscribe(e=>{
-    const {player,target} = e
+    const {player,target: simulatedPlayer} = e
     if(!player || player.typeId!=='minecraft:player')return
-    if(!target || !simulatedPlayerManager.has(target))return// world.sendMessage('meow~ target');
-    const simulatedPlayer = target // what's unknow?
-    if(!simulatedPlayer)return
+    if(!simulatedPlayer || !simulatedPlayerManager.has(simulatedPlayer))return// world.sendMessage('meow~ target');
     e.cancel=true
 
     const tagManager = ()=>{


### PR DESCRIPTION
- refactor(gui): 形参命名统一改为 `simulatedPlayer`
- refactor(gui): 去除冗余非空守卫
  - 前置 `simulatedPlayerManager.has(target)` 已可确认 `target` 非空
  - 无需二次判断
- fix(gui): 移除交叉类型
- refactor(gui): 移除早期基于攻击的 GUI 触发器