### PR TITLE
refactor(inventory)!: 优化代码 抽离重复代码

### DIFF
--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -12,7 +12,7 @@ commandManager.add(['假人装备交换','假人交换装备'], ({player,simulat
     const p = player.getComponent("minecraft:equippable") // player
     for (const i in  EquipmentSlot) {
         //跳过主手
-        if (i === EquipmentSlot['Mainhand']) continue
+        if (i === EquipmentSlot.Mainhand) continue
         // console.error(i)
         const _ = s.getEquipment(<EquipmentSlot>i)
         const __ = p.getEquipment(<EquipmentSlot>i)

--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -1,15 +1,15 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EquipmentSlot } from "@minecraft/server";
+import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.add(['假人装备交换','假人交换装备'], ({player,simulatedPlayer: sim}) => {
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
     if(!player && !sim)return
 
-    const s = simulatedPlayer.getComponent("minecraft:equippable") // SimPlayer
+    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable) // SimPlayer
 
-    const p = player.getComponent("minecraft:equippable") // player
+    const p = player.getComponent(EntityComponentTypes.Equippable) // player
     for (const i in  EquipmentSlot) {
         //跳过主手
         if (i === EquipmentSlot.Mainhand) continue

--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -10,6 +10,6 @@ commandManager.add(['假人装备交换','假人交换装备'], ({player,simulat
 
     for (const i in  EquipmentSlot) {
         if (i === EquipmentSlot.Mainhand) continue
-        swapEquipment(player, simulatedPlayer, <EquipmentSlot>i)
+        swapEquipment(player, simulatedPlayer, EquipmentSlot[i])
     }
 });

--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -5,8 +5,8 @@ import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
 commandManager.add(['假人装备交换','假人交换装备'], ({player,simulatedPlayer: sim}) => {
-    const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
     if(!player && !sim)return
+    const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
     for (const i in  EquipmentSlot) {
         if (i === EquipmentSlot.Mainhand) continue

--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -1,22 +1,15 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
+import { swapEquipment } from "./utils";
 
 commandManager.add(['假人装备交换','假人交换装备'], ({player,simulatedPlayer: sim}) => {
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
     if(!player && !sim)return
 
-    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable) // SimPlayer
-
-    const p = player.getComponent(EntityComponentTypes.Equippable) // player
     for (const i in  EquipmentSlot) {
-        //跳过主手
         if (i === EquipmentSlot.Mainhand) continue
-        // console.error(i)
-        const _ = s.getEquipment(<EquipmentSlot>i)
-        const __ = p.getEquipment(<EquipmentSlot>i)
-        s.setEquipment(<EquipmentSlot>i, __) //set SimPlayer item
-        p.setEquipment(<EquipmentSlot>i, _) //set player item
+        swapEquipment(player, simulatedPlayer, <EquipmentSlot>i)
     }
 });

--- a/src/features/inventory/inventory-swap.ts
+++ b/src/features/inventory/inventory-swap.ts
@@ -1,5 +1,6 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
+import { EntityComponentTypes } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.add(['假人背包交换','假人交换背包'], ({player,simulatedPlayer: sim}) => {
@@ -7,9 +8,9 @@ commandManager.add(['假人背包交换','假人交换背包'], ({player,simulat
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
     if(!simulatedPlayer)return
 
-    const s = simulatedPlayer.getComponent("minecraft:inventory").container
+    const s = simulatedPlayer.getComponent(EntityComponentTypes.Inventory).container
 
-    const p = player.getComponent("minecraft:inventory").container
+    const p = player.getComponent(EntityComponentTypes.Inventory).container
 
     for
     (

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -1,15 +1,15 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EquipmentSlot } from "@minecraft/server";
+import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.add('假人主手物品交换', ({player,simulatedPlayer: sim}) => {
 
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
-    const s = simulatedPlayer.getComponent("minecraft:equippable")
+    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable)
 
-    const p = player.getComponent("minecraft:equippable")
+    const p = player.getComponent(EntityComponentTypes.Equippable)
     const i = EquipmentSlot.Mainhand
     const _ = s.getEquipment(i)
     const __ = p.getEquipment(i)

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -1,18 +1,12 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
+import { swapEquipment } from "./utils";
 
 commandManager.add('假人主手物品交换', ({player,simulatedPlayer: sim}) => {
 
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
-    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable)
-
-    const p = player.getComponent(EntityComponentTypes.Equippable)
-    const i = EquipmentSlot.Mainhand
-    const _ = s.getEquipment(i)
-    const __ = p.getEquipment(i)
-    s.setEquipment(i, __)
-    p.setEquipment(i, _)
+    swapEquipment(player, simulatedPlayer, EquipmentSlot.Mainhand)
 });

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -5,7 +5,6 @@ import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
 commandManager.add('假人主手物品交换', ({player,simulatedPlayer: sim}) => {
-
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
     swapEquipment(player, simulatedPlayer, EquipmentSlot.Mainhand)

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -10,7 +10,7 @@ commandManager.add('假人主手物品交换', ({player,simulatedPlayer: sim}) =
     const s = simulatedPlayer.getComponent("minecraft:equippable")
 
     const p = player.getComponent("minecraft:equippable")
-    const i = EquipmentSlot['Mainhand'] ?? EquipmentSlot['mainhand']
+    const i = EquipmentSlot.Mainhand
     const _ = s.getEquipment(i)
     const __ = p.getEquipment(i)
     s.setEquipment(i, __)

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -11,8 +11,8 @@ commandManager.add('假人主手物品交换', ({player,simulatedPlayer: sim}) =
 
     const p = player.getComponent("minecraft:equippable")
     const i = EquipmentSlot['Mainhand'] ?? EquipmentSlot['mainhand']
-    const _ = s.getEquipment(<EquipmentSlot>i)
-    const __ = p.getEquipment(<EquipmentSlot>i)
-    s.setEquipment(<EquipmentSlot>i, __)
-    p.setEquipment(<EquipmentSlot>i, _)
+    const _ = s.getEquipment(i)
+    const __ = p.getEquipment(i)
+    s.setEquipment(i, __)
+    p.setEquipment(i, _)
 });

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -11,8 +11,8 @@ commandManager.add('假人副手物品交换', ({player,simulatedPlayer: sim}) =
 
     const p = player.getComponent("minecraft:equippable")
     const i = EquipmentSlot['Offhand'] ?? EquipmentSlot['offhand']
-    const _ = s.getEquipment(<EquipmentSlot>i)
-    const __ = p.getEquipment(<EquipmentSlot>i)
-    s.setEquipment(<EquipmentSlot>i, __)
-    p.setEquipment(<EquipmentSlot>i, _)
+    const _ = s.getEquipment(i)
+    const __ = p.getEquipment(i)
+    s.setEquipment(i, __)
+    p.setEquipment(i, _)
 });

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -5,7 +5,6 @@ import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
 commandManager.add('假人副手物品交换', ({player,simulatedPlayer: sim}) => {
-
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
     swapEquipment(player, simulatedPlayer, EquipmentSlot.Offhand)

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -1,15 +1,15 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EquipmentSlot } from "@minecraft/server";
+import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.add('假人副手物品交换', ({player,simulatedPlayer: sim}) => {
 
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
-    const s = simulatedPlayer.getComponent("minecraft:equippable")
+    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable)
 
-    const p = player.getComponent("minecraft:equippable")
+    const p = player.getComponent(EntityComponentTypes.Equippable)
     const i = EquipmentSlot.Offhand
     const _ = s.getEquipment(i)
     const __ = p.getEquipment(i)

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -10,7 +10,7 @@ commandManager.add('假人副手物品交换', ({player,simulatedPlayer: sim}) =
     const s = simulatedPlayer.getComponent("minecraft:equippable")
 
     const p = player.getComponent("minecraft:equippable")
-    const i = EquipmentSlot['Offhand'] ?? EquipmentSlot['offhand']
+    const i = EquipmentSlot.Offhand
     const _ = s.getEquipment(i)
     const __ = p.getEquipment(i)
     s.setEquipment(i, __)

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -1,18 +1,12 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
+import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
+import { swapEquipment } from "./utils";
 
 commandManager.add('假人副手物品交换', ({player,simulatedPlayer: sim}) => {
 
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
-    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable)
-
-    const p = player.getComponent(EntityComponentTypes.Equippable)
-    const i = EquipmentSlot.Offhand
-    const _ = s.getEquipment(i)
-    const __ = p.getEquipment(i)
-    s.setEquipment(i, __)
-    p.setEquipment(i, _)
+    swapEquipment(player, simulatedPlayer, EquipmentSlot.Offhand)
 });

--- a/src/features/inventory/recycle.ts
+++ b/src/features/inventory/recycle.ts
@@ -1,6 +1,6 @@
 import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
-import { EquipmentSlot } from "@minecraft/server";
+import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.add(['假人资源回收','假人背包清空','假人爆金币'], ({player,simulatedPlayer: sim})=>{
@@ -12,7 +12,7 @@ commandManager.add(['假人资源回收','假人背包清空','假人爆金币']
     const simulatedPlayer:SimulatedPlayer = sim ?? getSimPlayer.fromView(player)
     if(!simulatedPlayer)return
 
-    const equip = simulatedPlayer.getComponent("minecraft:equippable")
+    const equip = simulatedPlayer.getComponent(EntityComponentTypes.Equippable)
 
     // emmm你这变量名
     const { location:l, dimension:d } = player
@@ -29,7 +29,7 @@ commandManager.add(['假人资源回收','假人背包清空','假人爆金币']
         equip.setEquipment(<EquipmentSlot>i, null) //undefined? new ItemStack('air')?
     }
 
-    const { container:s } =  simulatedPlayer.getComponent("minecraft:inventory")
+    const { container:s } =  simulatedPlayer.getComponent(EntityComponentTypes.Inventory)
 
     for (
         let i = s.size;

--- a/src/features/inventory/utils.ts
+++ b/src/features/inventory/utils.ts
@@ -1,12 +1,12 @@
 import { EntityComponentTypes, type EquipmentSlot, type Player } from "@minecraft/server";
 
 export const swapEquipment = (playerA: Player, playerB: Player, slot: EquipmentSlot): void => {
-    const componentB = playerB.getComponent(EntityComponentTypes.Equippable);
     const componentA = playerA.getComponent(EntityComponentTypes.Equippable);
+    const componentB = playerB.getComponent(EntityComponentTypes.Equippable);
 
-    const itemB = componentB.getEquipment(slot);
     const itemA = componentA.getEquipment(slot);
+    const itemB = componentB.getEquipment(slot);
 
-    componentB.setEquipment(slot, itemA);
     componentA.setEquipment(slot, itemB);
+    componentB.setEquipment(slot, itemA);
 };

--- a/src/features/inventory/utils.ts
+++ b/src/features/inventory/utils.ts
@@ -1,0 +1,13 @@
+import { EntityComponentTypes, type EquipmentSlot, type Player } from "@minecraft/server";
+import type { SimulatedPlayer } from "@minecraft/server-gametest";
+
+export const swapEquipment = (player: Player, simulatedPlayer: SimulatedPlayer, slot: EquipmentSlot): void => {
+    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable);
+    const p = player.getComponent(EntityComponentTypes.Equippable);
+
+    const _ = s.getEquipment(slot);
+    const __ = p.getEquipment(slot);
+
+    s.setEquipment(slot, __);
+    p.setEquipment(slot, _);
+};

--- a/src/features/inventory/utils.ts
+++ b/src/features/inventory/utils.ts
@@ -1,12 +1,12 @@
 import { EntityComponentTypes, type EquipmentSlot, type Player } from "@minecraft/server";
 
 export const swapEquipment = (playerA: Player, playerB: Player, slot: EquipmentSlot): void => {
-    const s = playerB.getComponent(EntityComponentTypes.Equippable);
-    const p = playerA.getComponent(EntityComponentTypes.Equippable);
+    const componentB = playerB.getComponent(EntityComponentTypes.Equippable);
+    const componentA = playerA.getComponent(EntityComponentTypes.Equippable);
 
-    const _ = s.getEquipment(slot);
-    const __ = p.getEquipment(slot);
+    const itemB = componentB.getEquipment(slot);
+    const itemA = componentA.getEquipment(slot);
 
-    s.setEquipment(slot, __);
-    p.setEquipment(slot, _);
+    componentB.setEquipment(slot, itemA);
+    componentA.setEquipment(slot, itemB);
 };

--- a/src/features/inventory/utils.ts
+++ b/src/features/inventory/utils.ts
@@ -1,9 +1,8 @@
 import { EntityComponentTypes, type EquipmentSlot, type Player } from "@minecraft/server";
-import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-export const swapEquipment = (player: Player, simulatedPlayer: SimulatedPlayer, slot: EquipmentSlot): void => {
-    const s = simulatedPlayer.getComponent(EntityComponentTypes.Equippable);
-    const p = player.getComponent(EntityComponentTypes.Equippable);
+export const swapEquipment = (playerA: Player, playerB: Player, slot: EquipmentSlot): void => {
+    const s = playerB.getComponent(EntityComponentTypes.Equippable);
+    const p = playerA.getComponent(EntityComponentTypes.Equippable);
 
     const _ = s.getEquipment(slot);
     const __ = p.getEquipment(slot);


### PR DESCRIPTION
- 移除不再需要的类型断言

- 去除为适应不同版本 API 的空值合并

- 枚举成员访问由 `[]` 更改为 `.`

- 字符串字面量替换为 `EntityComponentTypes` 枚举 避免硬编码

- 抽离装备交换逻辑到单独文件

  提取 `swapEquipment` 函数到 `inventory/utils.ts`，统一管理装备槽位交换逻辑

- 泛化 `swapEquipment` 参数类型为 `Player`

- `swapEquipment` 函数内局部变量名语义化 提高可读性

- 调整 `swapEquipment` 函数内语句顺序

- 用枚举映射替代原类型断言

  类型断言 `<EquipmentSlot>i` 替换为 `EquipmentSlot[i]` 成员访问

- 调整非空守卫位置 避免潜在的空引用风险

- 移除部分多余空行

BREAKING CHANGE: 不再兼容旧版枚举 API (如全小写 `offhand`)