### PR TITLE
fix(reset-pid): 修复存在模拟玩家时重置 PID 导致被覆盖问题

### DIFF
--- a/src/core/simulated-player/errors.ts
+++ b/src/core/simulated-player/errors.ts
@@ -11,3 +11,10 @@ export class SimulatedPlayerNotFoundError extends Error {
         this.name = "SimulatedPlayerNotFoundError";
     }
 }
+
+export class ExistingSimulatedPlayersError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ExistingSimulatedPlayersError";
+    }
+}

--- a/src/core/simulated-player/manager.ts
+++ b/src/core/simulated-player/manager.ts
@@ -1,7 +1,7 @@
 import { PIDManager, type PID } from "../pid";
 import { Test, type SimulatedPlayer } from "@minecraft/server-gametest";
 import { DEFAULT_SIGNS } from "@/constants";
-import { SimulatedPlayerNotFoundError, NotReadyError } from "./errors";
+import { SimulatedPlayerNotFoundError, NotReadyError, ExistingSimulatedPlayersError } from "./errors";
 import type { Entity } from "@minecraft/server";
 import type { AddSimulatedPlayerOptions, SpawnSimulatedPlayerOptions } from "./types";
 
@@ -120,6 +120,9 @@ class SimulatedPlayerManager {
     }
 
     resetPID(): PID {
+        if(this._pidToSimulatedPlayer.size > 0)
+            throw new ExistingSimulatedPlayersError('Cannot reset PID while simulated players exist');
+        
         return this.pidManager.reset();
     }
 }

--- a/src/features/meta/reset-pid.ts
+++ b/src/features/meta/reset-pid.ts
@@ -10,7 +10,7 @@ commandManager.add(['假人重置序号', '假人编号重置', '假人序号重
         player?.sendMessage('以前是以前✋ ，现在是现在✋ ，你要是一直拿以前当作现在✋ ，哥们，你怎么不拿你开新档的时候对比')
     } catch (e) {
         if (e instanceof ExistingSimulatedPlayersError)
-            player?.sendMessage('请先移除所有模拟玩家');
+            player?.sendMessage('请先移除所有假人');
         else
             throw e;
     }

--- a/src/features/meta/reset-pid.ts
+++ b/src/features/meta/reset-pid.ts
@@ -1,10 +1,17 @@
 import { commandManager } from '@/core/command'
-import { simulatedPlayerManager } from '@/core/simulated-player';
+import { ExistingSimulatedPlayersError, simulatedPlayerManager } from '@/core/simulated-player';
 
 commandManager.add(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ player }) => {
-    const PID = simulatedPlayerManager.resetPID()
-    player?.sendMessage('重置成功，重置前为'+PID)
+    try {
+        const PID = simulatedPlayerManager.resetPID();
 
+        player?.sendMessage('重置成功，重置前为'+PID)
 
-    player?.sendMessage('以前是以前✋ ，现在是现在✋ ，你要是一直拿以前当作现在✋ ，哥们，你怎么不拿你开新档的时候对比')
+        player?.sendMessage('以前是以前✋ ，现在是现在✋ ，你要是一直拿以前当作现在✋ ，哥们，你怎么不拿你开新档的时候对比')
+    } catch (e) {
+        if (e instanceof ExistingSimulatedPlayersError)
+            player?.sendMessage('请先移除所有模拟玩家');
+        else
+            throw e;
+    }
 });


### PR DESCRIPTION
原先问题：重置 PID 后，如果新生成的模拟玩家 PID 与已存在的相同，则内部存储会将旧模拟玩家覆盖

增加了一个限制，不允许在已存在模拟玩家时进行重置