### PR TITLE
refactor(command): 再次重命名方法以提高语义清晰度

### DIFF
--- a/src/core/command/command.ts
+++ b/src/core/command/command.ts
@@ -8,7 +8,7 @@ export class Command implements Executable {
      * 
      * @param handler 注册的命令 handler，接受命令上下文对象。
      */
-    use(handler: Handler): void;
+    register(handler: Handler): void;
 
     /**
      * 注册有条件约束的命令处理回调。
@@ -17,8 +17,8 @@ export class Command implements Executable {
      * @param condition 条件回调，接受命令上下文对象，返回一个布尔值，仅当返回布尔值为 true 时才会执行对应的 handler。
      * @param handler 命令处理回调，接受命令上下文对象。
      */
-    use(condition: Condition, handler: Handler): void;
-    use(conditionOrHandler: Condition | Handler, handler?: Handler): void {
+    register(condition: Condition, handler: Handler): void;
+    register(conditionOrHandler: Condition | Handler, handler?: Handler): void {
         let condition: Condition;
         if (handler)
             condition = conditionOrHandler as Condition;

--- a/src/core/command/manager.ts
+++ b/src/core/command/manager.ts
@@ -46,7 +46,7 @@ class CommandManager {
      * add(['假人生成', '假人创建'], spawn);
      * ```
      */
-    add(prefixes: string | string[], rawHandler: Executable | Handler): void {
+    register(prefixes: string | string[], rawHandler: Executable | Handler): void {
         const prefixesArray = (Array.isArray(prefixes) ? prefixes : [prefixes])
             .map(prefix => prefix.toLowerCase());
 
@@ -80,7 +80,7 @@ class CommandManager {
      * @param prefixes - 要取消注册的命令前缀字符串或字符串数组。
      * @throws {CommandNotFoundError} 如果给定前缀未注册。
      */
-    remove(prefixes: string | string[]): void {
+    unregister(prefixes: string | string[]): void {
         const prefixesArray = (Array.isArray(prefixes) ? prefixes : [prefixes])
             .map(prefix => prefix.toLowerCase());
 
@@ -103,7 +103,7 @@ class CommandManager {
      * 该方法首先解析命令字符串，提取命令前缀和参数数组，
      * 然后将这些信息用于执行相应的命令。
      */
-    run(commandString: string, baseContext?: BaseContext): void;
+    execute(commandString: string, baseContext?: BaseContext): void;
 
     /**
      * 执行指定命令
@@ -114,16 +114,16 @@ class CommandManager {
      * 
      * @throws {CommandNotFoundError} 如果命令不存在。
      */
-    run(prefix: string, args: string[], baseContext: BaseContext): void;
+    execute(prefix: string, args: string[], baseContext: BaseContext): void;
 
-    run(commandStringOrPrefix: string, argsOrBaseContext: BaseContext | string[] = {}, baseContext?: BaseContext): void {
+    execute(commandStringOrPrefix: string, argsOrBaseContext: BaseContext | string[] = {}, baseContext?: BaseContext): void {
         if (Array.isArray(argsOrBaseContext))
-            this.runCommand(commandStringOrPrefix, argsOrBaseContext, baseContext!);
+            this.executeCommand(commandStringOrPrefix, argsOrBaseContext, baseContext!);
         else
-            this.runString(commandStringOrPrefix, argsOrBaseContext);
+            this.executeString(commandStringOrPrefix, argsOrBaseContext);
     }
 
-    private runCommand(prefix: string, args: string[], baseContext: BaseContext): void {
+    private executeCommand(prefix: string, args: string[], baseContext: BaseContext): void {
         prefix = prefix.toLowerCase();
         const command = this.prefixToHandlerMap.get(prefix);
         if (!command)
@@ -136,10 +136,10 @@ class CommandManager {
         command({ prefix, args, ...baseContext });
     }
 
-    private runString(commandString: string, baseContext: BaseContext = {}): void {
+    private executeString(commandString: string, baseContext: BaseContext = {}): void {
         const { prefix, args } = parseCommandString(commandString);
 
-        this.runCommand(prefix, args, baseContext);
+        this.executeCommand(prefix, args, baseContext);
     }
 
     /**

--- a/src/features/behaviors/behaviors.ts
+++ b/src/features/behaviors/behaviors.ts
@@ -73,7 +73,7 @@ const behaviorPrefix = '假人';
 
 const registerBehaviorCommands = () => {
     behaviorCommandConfigs.forEach(behaviorCommand => {
-        commandManager.add(`${behaviorPrefix}${behaviorCommand.behavior}`, ({ player }) => {
+        commandManager.register(`${behaviorPrefix}${behaviorCommand.behavior}`, ({ player }) => {
             if (!player) return;
             const simulatedPlayer = getSimPlayer.fromView(player);
             if (!simulatedPlayer) return;

--- a/src/features/behaviors/break-block.ts
+++ b/src/features/behaviors/break-block.ts
@@ -7,7 +7,7 @@ import { SIGN } from "@/constants";
 import { gameTestManager } from '@/core/gametest';
 
 const breakBlockCommand = new Command();
-breakBlockCommand.use(({ args }) => args.length === 0, ({ player }) => {
+breakBlockCommand.register(({ args }) => args.length === 0, ({ player }) => {
     if (!player) {
         console.error('error not isEntity');
         return;
@@ -21,7 +21,7 @@ breakBlockCommand.use(({ args }) => args.length === 0, ({ player }) => {
 
     simulatedPlayer.addTag(SIGN.AUTO_BREAKBLOCK_SIGN);
 });
-commandManager.add(['假人挖掘', '假人摧毁'], breakBlockCommand);
+commandManager.register(['假人挖掘', '假人摧毁'], breakBlockCommand);
 
 // task
 const breaks = () =>

--- a/src/features/command-triggers/chat-send.ts
+++ b/src/features/command-triggers/chat-send.ts
@@ -5,7 +5,7 @@ import { Messages } from "@/constants";
 world.beforeEvents.chatSend.subscribe(({message, sender}) => {
     system.run(() => {
         try {
-            commandManager.run(message, {
+            commandManager.execute(message, {
                 player: sender,
                 location: sender.location,
                 dimension: sender.dimension

--- a/src/features/command-triggers/script-event.ts
+++ b/src/features/command-triggers/script-event.ts
@@ -71,7 +71,7 @@ system.afterEvents.scriptEventReceive.subscribe(e => {
     const commandString = parseScriptEventString(e);
 
     try {
-        commandManager.run(commandString, baseContext);
+        commandManager.execute(commandString, baseContext);
     } catch (e) {
         console.error(e);
         if (e instanceof CommandNotFoundError)

--- a/src/features/gui.ts
+++ b/src/features/gui.ts
@@ -18,9 +18,9 @@ const BEHAVIOR_HANDLERS = {
     useItemInSlot: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.useItemInSlot(simulatedPlayer.selectedSlotIndex),
     stopUsingItem: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.stopUsingItem(),
     interact: (simulatedPlayer: SimulatedPlayer) => simulatedPlayer.interact(),
-    swapMainhandItem: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人主手物品交换', { player, simulatedPlayer }),
-    swapInventory: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人背包交换', { player, simulatedPlayer }),
-    swapEquipment: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人装备交换', { player, simulatedPlayer }),
+    swapMainhandItem: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.execute('假人主手物品交换', { player, simulatedPlayer }),
+    swapInventory: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.execute('假人背包交换', { player, simulatedPlayer }),
+    swapEquipment: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.execute('假人装备交换', { player, simulatedPlayer }),
     rename: async (simulatedPlayer: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
 
@@ -37,8 +37,8 @@ const BEHAVIOR_HANDLERS = {
         simulatedPlayer.nameTag = <string>formValues[0];
         // commandManager.executeCommand('假人改名', [name], { entity: player, simulatedPlayer });
     },
-    recycle: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.run('假人资源回收', { player, simulatedPlayer }), // item and exp
-    disconnect: (simulatedPlayer: SimulatedPlayer) => commandManager.run('假人销毁', { simulatedPlayer }),
+    recycle: (simulatedPlayer: SimulatedPlayer, player: Player) => commandManager.execute('假人资源回收', { player, simulatedPlayer }), // item and exp
+    disconnect: (simulatedPlayer: SimulatedPlayer) => commandManager.execute('假人销毁', { simulatedPlayer }),
 };
 
 export const exeBehavior = (behavior: string) => BEHAVIOR[behavior] && BEHAVIOR_HANDLERS[behavior];

--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -4,7 +4,7 @@ import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
-commandManager.add(['假人装备交换','假人交换装备'], ({player,simulatedPlayer: sim}) => {
+commandManager.register(['假人装备交换','假人交换装备'], ({player,simulatedPlayer: sim}) => {
     if(!player && !sim)return
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 

--- a/src/features/inventory/inventory-swap.ts
+++ b/src/features/inventory/inventory-swap.ts
@@ -3,7 +3,7 @@ import { getSimPlayer } from "@/core/queries";
 import { EntityComponentTypes } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.add(['假人背包交换','假人交换背包'], ({player,simulatedPlayer: sim}) => {
+commandManager.register(['假人背包交换','假人交换背包'], ({player,simulatedPlayer: sim}) => {
     if(!player && !sim)return
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
     if(!simulatedPlayer)return

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -4,7 +4,7 @@ import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
-commandManager.add('假人主手物品交换', ({player,simulatedPlayer: sim}) => {
+commandManager.register('假人主手物品交换', ({player,simulatedPlayer: sim}) => {
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
     swapEquipment(player, simulatedPlayer, EquipmentSlot.Mainhand)

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -4,7 +4,7 @@ import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
-commandManager.add('假人副手物品交换', ({player,simulatedPlayer: sim}) => {
+commandManager.register('假人副手物品交换', ({player,simulatedPlayer: sim}) => {
     const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
 
     swapEquipment(player, simulatedPlayer, EquipmentSlot.Offhand)

--- a/src/features/inventory/recycle.ts
+++ b/src/features/inventory/recycle.ts
@@ -3,7 +3,7 @@ import { getSimPlayer } from "@/core/queries";
 import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.add(['假人资源回收','假人背包清空','假人爆金币'], ({player,simulatedPlayer: sim})=>{
+commandManager.register(['假人资源回收','假人背包清空','假人爆金币'], ({player,simulatedPlayer: sim})=>{
     if(!player && !sim) {
         console.error('error not isEntity')
         return

--- a/src/features/lifecycle/disconnect.ts
+++ b/src/features/lifecycle/disconnect.ts
@@ -4,7 +4,7 @@ import { getSimPlayer } from "@/core/queries";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.add(['假人销毁','假人移除','假人清除'], ({player,args:[simIndex],simulatedPlayer: sim}) => {
+commandManager.register(['假人销毁','假人移除','假人清除'], ({player,args:[simIndex],simulatedPlayer: sim}) => {
     if(sim)return simulatedPlayerManager.remove(sim);
 
     // TODO: 支持scriptevent
@@ -16,7 +16,7 @@ commandManager.add(['假人销毁','假人移除','假人清除'], ({player,args
         const simulatedPlayer:SimulatedPlayer = getSimPlayer.fromView(player)
         if(!simulatedPlayer)return player.sendMessage("§e§l-面前不存在模拟玩家")
 
-        commandManager.run('假人背包清空', [], { player, simulatedPlayer: simulatedPlayer ,location: player.location, dimension: player.dimension})
+        commandManager.execute('假人背包清空', [], { player, simulatedPlayer: simulatedPlayer ,location: player.location, dimension: player.dimension})
         player.sendMessage("§e§l-拜拜了您内")
         simulatedPlayerManager.remove(simulatedPlayer)
     }
@@ -29,7 +29,7 @@ commandManager.add(['假人销毁','假人移除','假人清除'], ({player,args
 
         if(!simulatedPlayer)return player.sendMessage("§e§l-不存在模拟玩家"+index)
 
-        commandManager.run('假人背包清空', [], { player, simulatedPlayer: simulatedPlayer ,location: player.location, dimension: player.dimension})
+        commandManager.execute('假人背包清空', [], { player, simulatedPlayer: simulatedPlayer ,location: player.location, dimension: player.dimension})
         player.sendMessage("§e§l-拜拜了您内")
         simulatedPlayerManager.remove(simulatedPlayer)
     }

--- a/src/features/lifecycle/respawn.ts
+++ b/src/features/lifecycle/respawn.ts
@@ -4,7 +4,7 @@ import { getSimPlayer } from "@/core/queries";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.add(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'],
+commandManager.register(['假人重生', '假人复活', '复活吧，我的爱人', '复活吧！我的爱人', '复活吧!我的爱人', '复活吧我的爱人'],
     ({ player, args: [simIndex] }) => {
 
     if (!player && simIndex === undefined) {

--- a/src/features/lifecycle/spawn.ts
+++ b/src/features/lifecycle/spawn.ts
@@ -23,12 +23,12 @@ const addSimulatedPlayer = (entity: Player | undefined, location: Vector3, dimen
 const chatSpawnCommand = new Command();
 
 // 假人生成
-chatSpawnCommand.use(({ args }) => args.length === 0, ({ player, location, dimension }) => {
+chatSpawnCommand.register(({ args }) => args.length === 0, ({ player, location, dimension }) => {
     addSimulatedPlayer(player, location, dimension);
 });
 
 // 假人生成 批量 count
-chatSpawnCommand.use(({ args }) => args[0] === '批量', ({ args: [, countString], player, location, dimension }) => {
+chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countString], player, location, dimension }) => {
     if (!countString) return player?.sendMessage('[模拟玩家] 命令错误，请提供数字');
     if (!Number.isSafeInteger(Number(countString))) return player?.sendMessage('[模拟玩家] 命令错误，期待数字却得到 ' + countString);
 
@@ -38,13 +38,13 @@ chatSpawnCommand.use(({ args }) => args[0] === '批量', ({ args: [, countString
 });
 
 // 假人生成 name
-chatSpawnCommand.use(({ args }) => args.length === 1, ({ args: [targetName], player, location, dimension }) => {
+chatSpawnCommand.register(({ args }) => args.length === 1, ({ args: [targetName], player, location, dimension }) => {
     addSimulatedPlayer(player, location, dimension, targetName);
 });
 
 // #56 参考：
 // 假人生成 x y z name 维度序号（数字 0-主世界 1-下界 2-末地）
-chatSpawnCommand.use(
+chatSpawnCommand.register(
     ({ args }) => args.length >= 3,
     ({
         args: [targetX, targetY, targetZ, targetName, targetDimension],
@@ -91,11 +91,11 @@ chatSpawnCommand.use(
 );
 
 // 捕获命令参数数量错误并提示
-chatSpawnCommand.use(({ args, player }) => {
+chatSpawnCommand.register(({ args, player }) => {
     player?.sendMessage(`[模拟玩家] 命令错误，期待3个坐标数字(x y z)或1个名称字符串("名称")，得到个数为${args.length}。带空格名称需用引号包裹`);
 });
 
-commandManager.add(['假人生成', '假人创建', 'ffpp'], chatSpawnCommand);
+commandManager.register(['假人生成', '假人创建', 'ffpp'], chatSpawnCommand);
 
 // world.afterEvents.chatSend.subscribe(({message, sender})=>{
 //     const cmdArgs = CommandRegistry.parse(message)

--- a/src/features/meta/help.ts
+++ b/src/features/meta/help.ts
@@ -67,7 +67,7 @@ const qrcodeTextRoll =
 11111111111111111111111111111111111`.replaceAll('0','  ').replaceAll('1','⬛')
 
 const helpCommand = new Command();
-helpCommand.use(({ args, player }) => player && args.length === 0, ({ player }) => {
+helpCommand.register(({ args, player }) => player && args.length === 0, ({ player }) => {
         [
             "输入  假人帮助+空格+功能名   获取更详细的帮助", "例如   -假人帮助 重生-",
             "###部分功能需要光标对准假人", "创建", "销毁", "列表", "扭头", "停止", "移动","§e§l自动追击§r",
@@ -84,7 +84,7 @@ helpCommand.use(({ args, player }) => player && args.length === 0, ({ player }) 
             "输入‘假人github’了解更多"
         ].forEach((text) => player.sendMessage(`§e§l-${text}`));
 });
-helpCommand.use(({ args, player }) => player && args.length > 0, ({ args: [item], player }) => {
+helpCommand.register(({ args, player }) => player && args.length > 0, ({ args: [item], player }) => {
     const helpMessage =
         ({
             "创建": ["创建示例", "假人创建", "假人创建 + 空格 + x y z", "假人创建 100 50 0", "假人创建 + 空格 + name", "假人创建 \"fake player\""],
@@ -101,11 +101,11 @@ helpCommand.use(({ args, player }) => player && args.length > 0, ({ args: [item]
             player.sendMessage("对不起，没有这种事情，做不到" + (Math.random() < 0.233 ? "给钱也做不到" : "真做不到"));
 });
 
-commandManager.add(['假人帮助', '假人help'], helpCommand)
+commandManager.register(['假人帮助', '假人help'], helpCommand)
 
 const githubCommand = new Command();
-githubCommand.use(({ player }) => player.sendMessage('§rhttps://github.com/xBoyMinemc 能不能扫上随缘\u000a' + (Math.random() > 0.5 ? qrcodeTextGithub : qrcodeTextRoll)));
-commandManager.add('假人github', githubCommand);
+githubCommand.register(({ player }) => player.sendMessage('§rhttps://github.com/xBoyMinemc 能不能扫上随缘\u000a' + (Math.random() > 0.5 ? qrcodeTextGithub : qrcodeTextRoll)));
+commandManager.register('假人github', githubCommand);
 
 
 // console.error('[假人]内置插件help加载成功')

--- a/src/features/meta/list-commands.ts
+++ b/src/features/meta/list-commands.ts
@@ -1,5 +1,5 @@
 import { commandManager } from "@/core/command";
 
-commandManager.add(['showshowway', '假人命令列表'], ({ player }) => {
+commandManager.register(['showshowway', '假人命令列表'], ({ player }) => {
     player?.sendMessage(commandManager.prefixes.join('\n'));
 });

--- a/src/features/meta/list-simulated-players.ts
+++ b/src/features/meta/list-simulated-players.ts
@@ -2,7 +2,7 @@ import { commandManager } from "@/core/command";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import { world } from "@minecraft/server";
 
-commandManager.add('假人列表', ({player}) => {
+commandManager.register('假人列表', ({player}) => {
     let target = player ?? world;
     if (simulatedPlayerManager.simulatedPlayers.size === 0) return target.sendMessage('列表空的');
     for (const [index, simulatedPlayer] of simulatedPlayerManager.simulatedPlayers) {

--- a/src/features/meta/location.ts
+++ b/src/features/meta/location.ts
@@ -5,7 +5,7 @@ import { getSimPlayer } from "@/core/queries";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.add(['假人位置', '假人坐标'], ({ player, args: [simIndex] }) => {
+commandManager.register(['假人位置', '假人坐标'], ({ player, args: [simIndex] }) => {
     if (!player && simIndex === undefined) {
         console.error('error not isEntity');
         return;

--- a/src/features/meta/rename.ts
+++ b/src/features/meta/rename.ts
@@ -2,7 +2,7 @@ import { commandManager } from "@/core/command";
 import { getSimPlayer } from "@/core/queries";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
-commandManager.add(['假人改名', '假人重命名', '假人换名'], ({player,args:[newName]}) => {
+commandManager.register(['假人改名', '假人重命名', '假人换名'], ({player,args:[newName]}) => {
     if(!player) {
         console.error('error not isEntity')
         return

--- a/src/features/meta/reset-pid.ts
+++ b/src/features/meta/reset-pid.ts
@@ -1,7 +1,7 @@
 import { commandManager } from '@/core/command'
 import { ExistingSimulatedPlayersError, simulatedPlayerManager } from '@/core/simulated-player';
 
-commandManager.add(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ player }) => {
+commandManager.register(['假人重置序号', '假人编号重置', '假人序号重置', '假人重置编号'], ({ player }) => {
     try {
         const PID = simulatedPlayerManager.resetPID();
 

--- a/src/features/meta/time.ts
+++ b/src/features/meta/time.ts
@@ -1,7 +1,7 @@
 import { commandManager } from "@/core/command";
 import { TicksPerSecond } from "@minecraft/server";
 
-commandManager.add(['假人时区', '假人时间'], ({player}) => {
+commandManager.register(['假人时区', '假人时间'], ({player}) => {
     // entity.sendMessage(''+Intl.DateTimeFormat().resolvedOptions().timeZone)
 
     const now = new Date()

--- a/src/features/tps.ts
+++ b/src/features/tps.ts
@@ -18,7 +18,7 @@ tpsMonitor.tpsUpdate.subscribe(({ tps }) => {
     });
 });
 
-commandManager.add('tps开', ({ player }) => {
+commandManager.register('tps开', ({ player }) => {
     if (!player) return;
 
     player.addTag(TPS_TAG);
@@ -26,7 +26,7 @@ commandManager.add('tps开', ({ player }) => {
     autoSwitchTPS();
 });
 
-commandManager.add('tps关', ({ player }) => {
+commandManager.register('tps关', ({ player }) => {
     if (!player) return;
 
     player.removeTag(TPS_TAG);


### PR DESCRIPTION
认为简化后的方法名语义清晰度不佳，还原了部分方法的名称，包含一些额外的修改

- Command
  - use → register (reload)

- CommandManager
  - add → register
  - remove → unregister
  - run → execute (reload)
  - runCommand → executeCommand (private)
  - runString → executeString (private)