### PR TITLE
build(tsconfig): `module` 由 es2020 更新为 es2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es2020",                                /* Specify what module code is generated. */
+    "module": "es2022",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
以使用 top-level await