### PR TITLE
refactor(features): 封装函数 `initialize()` 自动递归导入功能模块

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@minecraft/server": "2.0.0-beta.1.21.80-stable",
         "@minecraft/server-gametest": "1.0.0-beta.1.21.80-stable",
         "@minecraft/server-ui": "2.0.0-beta.1.21.80-stable",
+        "@types/webpack-env": "^1.18.8",
         "archiver": "latest",
         "clean-webpack-plugin": "^4.0.0",
         "ts-loader": "^9.5.2",
@@ -233,6 +234,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmmirror.com/@types/webpack-env/-/webpack-env-1.18.8.tgz",
+      "integrity": "sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@minecraft/server": "2.0.0-beta.1.21.80-stable",
     "@minecraft/server-gametest": "1.0.0-beta.1.21.80-stable",
     "@minecraft/server-ui": "2.0.0-beta.1.21.80-stable",
+    "@types/webpack-env": "^1.18.8",
     "archiver": "latest",
     "clean-webpack-plugin": "^4.0.0",
     "ts-loader": "^9.5.2",

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,30 +1,5 @@
-export * from './task';
-export * from './gui';
-export * from './killedBySimPlayer';
+const context = require.context('.', true, /\.ts$/);
 
-export * from './command-triggers';
-
-export * from './meta/help';
-export * from './meta/list-simulated-players';
-export * from './meta/location';
-export * from './meta/rename';
-export * from './meta/reset-pid';
-export * from './meta/list-commands';
-export * from './meta/time';
-
-export * from './lifecycle/spawn';
-export * from './lifecycle/disconnect';
-export * from './lifecycle/respawn';
-
-export * from './inventory/equipment-swap';
-export * from './inventory/inventory-swap';
-export * from './inventory/mainhand-swap';
-export * from './inventory/offhand-swap';
-export * from './inventory/recycle';
-
-export * from './behaviors/behaviors';
-export * from './behaviors/break-block';
-
-export * from './tps'
-
-export * from './initialization/initialize';
+export const initialize = () => context
+    .keys()
+    .map((key) => context(key));

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,5 +1,3 @@
 const context = require.context('.', true, /\.ts$/);
 
-export const initialize = () => context
-    .keys()
-    .map((key) => context(key));
+export const initialize = () => context.keys().map(context);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { world } from '@minecraft/server';
 
-world.afterEvents.worldLoad.subscribe(() => import('@/main/main'));
+world.afterEvents.worldLoad.subscribe(() => import('@/features'));
 // 2025-5-8  1.21.80 又出问题 通过延迟到 worldLoad 事件解决
 // 2024-11-4 这里是为了解决一个莫名其妙的1.21.50触发的bug，当包加载的时候，加载world的部分方法会崩。而异步可以解决

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { world } from '@minecraft/server';
+import { initialize } from '@/features';
 
-world.afterEvents.worldLoad.subscribe(() => import('@/features'));
+world.afterEvents.worldLoad.subscribe(initialize);
 // 2025-5-8  1.21.80 又出问题 通过延迟到 worldLoad 事件解决
 // 2024-11-4 这里是为了解决一个莫名其妙的1.21.50触发的bug，当包加载的时候，加载world的部分方法会崩。而异步可以解决

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,1 +1,0 @@
-import '@/features'


### PR DESCRIPTION
使用 webpack API 加载所有功能模块，避免手动维护列表

- 移除 `features` 目录下所有硬编码的模块导出
- 使用 webpack API 动态模块加载
- 封装为函数 `initialize()` 通过调用该函数显式控制加载时机
- 移除文件 `main/main.ts`