### PR TITLE
fix(tps): 由于导入时机的更改，立即执行一次 `autoSwitchTPS()`

### DIFF
--- a/src/features/tps.ts
+++ b/src/features/tps.ts
@@ -46,3 +46,6 @@ const autoSwitchTPS = (): void => {
 };
 
 EVENTS.forEach(event => event.subscribe(autoSwitchTPS));
+
+// 立即执行一次
+autoSwitchTPS();


### PR DESCRIPTION
确保进入世界能及时开启 tps