### PR TITLE
refactor(command-triggers): 删除不再需要的 `index.ts`

### DIFF
--- a/src/features/command-triggers/index.ts
+++ b/src/features/command-triggers/index.ts
@@ -1,2 +1,0 @@
-export * from './chat-send';
-export * from './script-event';


### PR DESCRIPTION
由于自动导入