### PR TITLE
refactor(queries)!: 重构实体获取工具函数

### DIFF
--- a/src/features/behaviors/behaviors.ts
+++ b/src/features/behaviors/behaviors.ts
@@ -1,5 +1,5 @@
 import { SIGN } from '@/constants';
-import { getSimPlayer } from '@/utils';
+import { getSimulatedPlayerFromView } from '@/utils';
 import { commandManager } from '@/core/command';
 
 interface BehaviorCommandConfig {
@@ -75,7 +75,7 @@ const registerBehaviorCommands = () => {
     behaviorCommandConfigs.forEach(({ behavior, adds, removes }) => {
         commandManager.register(`${behaviorPrefix}${behavior}`, ({ player }) => {
             if (!player) return;
-            const simulatedPlayer = getSimPlayer.fromView(player);
+            const simulatedPlayer = getSimulatedPlayerFromView(player);
             if (!simulatedPlayer) return;
 
             adds.forEach(tag => {

--- a/src/features/behaviors/break-block.ts
+++ b/src/features/behaviors/break-block.ts
@@ -1,7 +1,7 @@
 import type { SimulatedPlayer } from '@minecraft/server-gametest';
 
 import { Command, commandManager } from '@/core/command';
-import { getSimPlayer } from '@/utils';
+import { getSimulatedPlayerFromView } from '@/utils';
 import { world, system } from "@minecraft/server";
 import { SIGN } from "@/constants";
 import { gameTestManager } from '@/core/gametest';
@@ -13,7 +13,7 @@ breakBlockCommand.register(({ args }) => args.length === 0, ({ player }) => {
         return;
     }
 
-    const simulatedPlayer: SimulatedPlayer = getSimPlayer.fromView(player);
+    const simulatedPlayer: SimulatedPlayer = getSimulatedPlayerFromView(player);
     if (!simulatedPlayer) {
         player.sendMessage('§e§l-面前不存在模拟玩家');
         return;

--- a/src/features/behaviors/task.ts
+++ b/src/features/behaviors/task.ts
@@ -34,7 +34,7 @@ function AUTO_BEHAVIOR() {
         if (simulatedPlayer.hasTag(SIGN.ATTACK_SIGN) && EntitiesFromView)
             simulatedPlayer.attackEntity(EntitiesFromView);
 
-        const EntitiesNear = getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 4);
+        const EntitiesNear = getClosestMob(simulatedPlayer, 4);
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesNear)
             simulatedPlayer.lookAtEntity(EntitiesNear);
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesFromView)
@@ -46,8 +46,8 @@ function AUTO_BEHAVIOR() {
 
         if (simulatedPlayer.hasTag(SIGN.AUTO_CHASE_SIGN)) {
             const target =
-                getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["undead"] }) ??
-                getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["monster"] }) ??
+                getClosestMob(simulatedPlayer, 12, { families: ["undead"] }) ??
+                getClosestMob(simulatedPlayer, 12, { families: ["monster"] }) ??
                 getClosestPlayer(simulatedPlayer, 12);
 
             let originalPosition = originalPositionMap.get(simulatedPlayer);

--- a/src/features/behaviors/task.ts
+++ b/src/features/behaviors/task.ts
@@ -34,7 +34,7 @@ function AUTO_BEHAVIOR() {
         if (simulatedPlayer.hasTag(SIGN.ATTACK_SIGN) && EntitiesFromView)
             simulatedPlayer.attackEntity(EntitiesFromView);
 
-        const EntitiesNear = getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 4, {})[0];
+        const EntitiesNear = getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 4)[0];
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesNear)
             simulatedPlayer.lookAtEntity(EntitiesNear);
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesFromView)
@@ -48,7 +48,7 @@ function AUTO_BEHAVIOR() {
             const entities = [
                 ...getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["undead"] }),
                 ...getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["monster"] }),
-                ...getClosestPlayer(simulatedPlayer, 12, {})
+                ...getClosestPlayer(simulatedPlayer, 12)
             ];
 
             let originalPosition = originalPositionMap.get(simulatedPlayer);

--- a/src/features/behaviors/task.ts
+++ b/src/features/behaviors/task.ts
@@ -2,7 +2,7 @@ import { SIGN } from '@/constants';
 import type { Vector3 } from '@minecraft/server';
 import { system } from '@minecraft/server';
 import type { SimulatedPlayer } from '@minecraft/server-gametest';
-import { getEntitiesNear, getPlayerNear } from '@/utils';
+import { getClosestMob, getClosestPlayer } from '@/utils';
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import { gameTestManager } from '@/core/gametest';
 
@@ -34,7 +34,7 @@ function AUTO_BEHAVIOR() {
         if (simulatedPlayer.hasTag(SIGN.ATTACK_SIGN) && EntitiesFromView)
             simulatedPlayer.attackEntity(EntitiesFromView);
 
-        const EntitiesNear = getEntitiesNear(simulatedPlayer.location, simulatedPlayer.dimension, 4, {})[0];
+        const EntitiesNear = getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 4, {})[0];
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesNear)
             simulatedPlayer.lookAtEntity(EntitiesNear);
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesFromView)
@@ -46,9 +46,9 @@ function AUTO_BEHAVIOR() {
 
         if (simulatedPlayer.hasTag(SIGN.AUTO_CHASE_SIGN)) {
             const entities = [
-                ...getEntitiesNear(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["undead"] }),
-                ...getEntitiesNear(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["monster"] }),
-                ...getPlayerNear(simulatedPlayer, 12, {})
+                ...getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["undead"] }),
+                ...getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["monster"] }),
+                ...getClosestPlayer(simulatedPlayer, 12, {})
             ];
 
             let originalPosition = originalPositionMap.get(simulatedPlayer);

--- a/src/features/behaviors/task.ts
+++ b/src/features/behaviors/task.ts
@@ -34,7 +34,7 @@ function AUTO_BEHAVIOR() {
         if (simulatedPlayer.hasTag(SIGN.ATTACK_SIGN) && EntitiesFromView)
             simulatedPlayer.attackEntity(EntitiesFromView);
 
-        const EntitiesNear = getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 4)[0];
+        const EntitiesNear = getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 4);
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesNear)
             simulatedPlayer.lookAtEntity(EntitiesNear);
         if (simulatedPlayer.hasTag(SIGN.AUTO_ATTACK_SIGN) && EntitiesFromView)
@@ -45,20 +45,18 @@ function AUTO_BEHAVIOR() {
                 system.runTimeout(() => simulatedPlayer.stopUsingItem(), 10);
 
         if (simulatedPlayer.hasTag(SIGN.AUTO_CHASE_SIGN)) {
-            const entities = [
-                ...getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["undead"] }),
-                ...getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["monster"] }),
-                ...getClosestPlayer(simulatedPlayer, 12)
-            ];
+            const target =
+                getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["undead"] }) ??
+                getClosestMob(simulatedPlayer.location, simulatedPlayer.dimension, 12, { families: ["monster"] }) ??
+                getClosestPlayer(simulatedPlayer, 12);
 
             let originalPosition = originalPositionMap.get(simulatedPlayer);
             if (!originalPosition) 
                 originalPositionMap.set(simulatedPlayer, simulatedPlayer.location);
 
-            if (entities.length > 0) {
+            if (target) {
 
                 // walk to target
-                const target = entities[0];
                 if (chebyshevDistance3(target.location, simulatedPlayer.location) <= 4)
                     simulatedPlayer.moveToLocation(gameTestManager.test.relativeLocation(target.location));
             } else if (originalPosition && chebyshevDistance3(simulatedPlayer.location, originalPosition) > 1) {

--- a/src/features/inventory/equipment-swap.ts
+++ b/src/features/inventory/equipment-swap.ts
@@ -1,12 +1,12 @@
 import { commandManager } from "@/core/command";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
 commandManager.register(['假人装备交换','假人交换装备'], ({player,simulatedPlayer: sim}) => {
     if(!player && !sim)return
-    const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
+    const simulatedPlayer:SimulatedPlayer = sim || getSimulatedPlayerFromView(player)
 
     for (const i in  EquipmentSlot) {
         if (i === EquipmentSlot.Mainhand) continue

--- a/src/features/inventory/inventory-swap.ts
+++ b/src/features/inventory/inventory-swap.ts
@@ -1,11 +1,11 @@
 import { commandManager } from "@/core/command";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { EntityComponentTypes } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.register(['假人背包交换','假人交换背包'], ({player,simulatedPlayer: sim}) => {
     if(!player && !sim)return
-    const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
+    const simulatedPlayer:SimulatedPlayer = sim || getSimulatedPlayerFromView(player)
     if(!simulatedPlayer)return
 
     const s = simulatedPlayer.getComponent(EntityComponentTypes.Inventory).container

--- a/src/features/inventory/mainhand-swap.ts
+++ b/src/features/inventory/mainhand-swap.ts
@@ -1,11 +1,11 @@
 import { commandManager } from "@/core/command";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
 commandManager.register('假人主手物品交换', ({player,simulatedPlayer: sim}) => {
-    const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
+    const simulatedPlayer:SimulatedPlayer = sim || getSimulatedPlayerFromView(player)
 
     swapEquipment(player, simulatedPlayer, EquipmentSlot.Mainhand)
 });

--- a/src/features/inventory/offhand-swap.ts
+++ b/src/features/inventory/offhand-swap.ts
@@ -1,11 +1,11 @@
 import { commandManager } from "@/core/command";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 import { swapEquipment } from "./utils";
 
 commandManager.register('假人副手物品交换', ({player,simulatedPlayer: sim}) => {
-    const simulatedPlayer:SimulatedPlayer = sim || getSimPlayer.fromView(player)
+    const simulatedPlayer:SimulatedPlayer = sim || getSimulatedPlayerFromView(player)
 
     swapEquipment(player, simulatedPlayer, EquipmentSlot.Offhand)
 });

--- a/src/features/inventory/recycle.ts
+++ b/src/features/inventory/recycle.ts
@@ -1,5 +1,5 @@
 import { commandManager } from "@/core/command";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { EntityComponentTypes, EquipmentSlot } from "@minecraft/server";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
@@ -9,7 +9,7 @@ commandManager.register(['假人资源回收','假人背包清空','假人爆金
         return
     }
 
-    const simulatedPlayer:SimulatedPlayer = sim ?? getSimPlayer.fromView(player)
+    const simulatedPlayer:SimulatedPlayer = sim ?? getSimulatedPlayerFromView(player)
     if(!simulatedPlayer)return
 
     const equip = simulatedPlayer.getComponent(EntityComponentTypes.Equippable)

--- a/src/features/lifecycle/disconnect.ts
+++ b/src/features/lifecycle/disconnect.ts
@@ -1,6 +1,6 @@
 import { commandManager } from "@/core/command";
 import type { PID } from "@/core/pid";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
@@ -13,7 +13,7 @@ commandManager.register(['假人销毁','假人移除','假人清除'], ({player
         return
     }
     if (simIndex === undefined) {
-        const simulatedPlayer:SimulatedPlayer = getSimPlayer.fromView(player)
+        const simulatedPlayer:SimulatedPlayer = getSimulatedPlayerFromView(player)
         if(!simulatedPlayer)return player.sendMessage("§e§l-面前不存在模拟玩家")
 
         commandManager.execute('假人背包清空', [], { player, simulatedPlayer: simulatedPlayer ,location: player.location, dimension: player.dimension})

--- a/src/features/lifecycle/respawn.ts
+++ b/src/features/lifecycle/respawn.ts
@@ -1,6 +1,6 @@
 import { commandManager } from "@/core/command";
 import type { PID } from "@/core/pid";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
@@ -16,7 +16,7 @@ commandManager.register(['假人重生', '假人复活', '复活吧，我的爱�
         ;
         ;"对准~";
         ;
-        const simulatedPlayer:SimulatedPlayer = getSimPlayer.fromView(player)
+        const simulatedPlayer:SimulatedPlayer = getSimulatedPlayerFromView(player)
         if(!simulatedPlayer)return player.sendMessage("§e§l-你不要怀疑，10000%是你没对准，如果假人真躺了的话")  //entity.sendMessage("§e§l-面前不存在模拟玩家")
         simulatedPlayer.respawn()
     }else {

--- a/src/features/meta/location.ts
+++ b/src/features/meta/location.ts
@@ -1,7 +1,7 @@
 import { dimensionMap } from "@/constants";
 import { commandManager } from "@/core/command";
 import type { PID } from "@/core/pid";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import { simulatedPlayerManager } from '@/core/simulated-player';
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
@@ -15,7 +15,7 @@ commandManager.register(['假人位置', '假人坐标'], ({ player, args: [simI
         ;
         ; "对准~";
         ;
-        simulatedPlayer = getSimPlayer.fromView(player);
+        simulatedPlayer = getSimulatedPlayerFromView(player);
         if (!simulatedPlayer) return player.sendMessage("§e§l-面前不存在模拟玩家");
     } else {
         const index = Number(simIndex);

--- a/src/features/meta/rename.ts
+++ b/src/features/meta/rename.ts
@@ -1,5 +1,5 @@
 import { commandManager } from "@/core/command";
-import { getSimPlayer } from "@/utils";
+import { getSimulatedPlayerFromView } from "@/utils";
 import type { SimulatedPlayer } from "@minecraft/server-gametest";
 
 commandManager.register(['假人改名', '假人重命名', '假人换名'], ({player,args:[newName]}) => {
@@ -13,7 +13,7 @@ commandManager.register(['假人改名', '假人重命名', '假人换名'], ({p
     ;
     ; "对准~";
     ;
-    const simulatedPlayer: SimulatedPlayer = getSimPlayer.fromView(player);
+    const simulatedPlayer: SimulatedPlayer = getSimulatedPlayerFromView(player);
     if (!simulatedPlayer) return player.sendMessage("§e§l-你不要怀疑，10000%是你没对准，如果假人真躺了的话");  //entity.sendMessage("§e§l-面前不存在模拟玩家")
     simulatedPlayer.nameTag = newName;
     player.sendMessage("§e§l-改名成功")

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -7,7 +7,7 @@ export function getSimulatedPlayerFromView(e: Entity, maxDistance = 16): Simulat
     return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
 }
 
-export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance:number, Options={}){
+export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance:number, Options={}): Entity{
     return dimension.getEntities({
         excludeTypes: ["minecraft:player", "minecraft:arrow", "minecraft:xp_orb", "minecraft:item"],
         closest: 1,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -20,7 +20,7 @@ export const getSimulatedPlayerFromView = (
 
 export const getClosestMob = (
     { dimension, location }: HasDimensionLocation,
-    maxDistance: number,
+    maxDistance: number = 16,
     options: Options = {}
 ): Entity | undefined => {
     return dimension.getEntities({
@@ -39,7 +39,7 @@ export const getClosestMob = (
 
 export const getClosestPlayer = (
     { dimension, location }: HasDimensionLocation,
-    maxDistance: number,
+    maxDistance: number = 16,
     options: Options = {}
 ): Player | undefined => {
     return dimension.getPlayers({

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -7,7 +7,7 @@ export function getSimulatedPlayerFromView(e: Entity, maxDistance = 16): Simulat
     return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
 }
 
-export function getEntitiesNear(location:Vector3, dimension:Dimension, maxDistance:number, Options={}){
+export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance:number, Options={}){
     const EntityQueryOption:EntityQueryOptions = {}
     EntityQueryOption.maxDistance = maxDistance
     EntityQueryOption.location    = location
@@ -16,7 +16,7 @@ export function getEntitiesNear(location:Vector3, dimension:Dimension, maxDistan
     Object.assign(EntityQueryOption,Options)
     return dimension.getEntities(EntityQueryOption)
 }
-export function getPlayerNear(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions):Player[] {
+export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions):Player[] {
     const EQO: EntityQueryOptions = {}
     EQO.maxDistance = maxDistance
     EQO.location    = who.location

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -3,11 +3,11 @@ import {SimulatedPlayer} from '@minecraft/server-gametest'
 import { SIGN } from '@/constants'
 
 
-export function getSimulatedPlayerFromView(e: Entity, maxDistance = 16): SimulatedPlayer {
+export const getSimulatedPlayerFromView = (e: Entity, maxDistance = 16): SimulatedPlayer => {
     return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
 }
 
-export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance:number, Options={}): Entity{
+export const getClosestMob = (location:Vector3, dimension:Dimension, maxDistance:number, Options={}): Entity =>{
     return dimension.getEntities({
         excludeTypes: ["minecraft:player", "minecraft:arrow", "minecraft:xp_orb", "minecraft:item"],
         closest: 1,
@@ -16,7 +16,7 @@ export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance
         ...Options,
     })[0];
 }
-export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions={}):Player {
+export const getClosestPlayer = (who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions={}):Player => {
     return who.dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,13 +1,12 @@
-import type {Block, Dimension, Entity, EntityQueryOptions, Player, Vector3} from '@minecraft/server'
-import {SimulatedPlayer} from '@minecraft/server-gametest'
-import { SIGN } from '@/constants'
-
+import { SIGN } from '@/constants';
+import type { Block, Dimension, Entity, EntityQueryOptions, Player, Vector3 } from '@minecraft/server';
+import type { SimulatedPlayer } from '@minecraft/server-gametest';
 
 export const getSimulatedPlayerFromView = (e: Entity, maxDistance = 16): SimulatedPlayer => {
     return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
-}
+};
 
-export const getClosestMob = (location:Vector3, dimension:Dimension, maxDistance:number, Options={}): Entity =>{
+export const getClosestMob = (location: Vector3, dimension: Dimension, maxDistance: number, Options = {}): Entity => {
     return dimension.getEntities({
         excludeTypes: ["minecraft:player", "minecraft:arrow", "minecraft:xp_orb", "minecraft:item"],
         closest: 1,
@@ -15,8 +14,9 @@ export const getClosestMob = (location:Vector3, dimension:Dimension, maxDistance
         maxDistance,
         ...Options,
     })[0];
-}
-export const getClosestPlayer = (who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions={}):Player => {
+};
+
+export const getClosestPlayer = (who: Entity | Block, maxDistance: number, defEntityQueryOptions: EntityQueryOptions = {}): Player => {
     return who.dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,
@@ -24,4 +24,4 @@ export const getClosestPlayer = (who:Entity|Block, maxDistance:number, defEntity
         maxDistance,
         ...defEntityQueryOptions,
     })[0];
-}
+};

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -3,11 +3,8 @@ import {SimulatedPlayer} from '@minecraft/server-gametest'
 import { SIGN } from '@/constants'
 
 
-// getEntitiesFromViewDirection
-export const getSimPlayer = {
-    // only one
-    fromView: (e:Entity,maxDistance=16):SimulatedPlayer=>(<SimulatedPlayer>e.getEntitiesFromViewDirection({maxDistance, tags: [SIGN.YUME_SIM_SIGN]})[0]?.entity),
-
+export function getSimulatedPlayerFromView(e: Entity, maxDistance = 16): SimulatedPlayer {
+    return (<SimulatedPlayer>e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity);
 }
 
 export function getEntitiesNear(location:Vector3, dimension:Dimension, maxDistance:number, Options={}){

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -21,7 +21,7 @@ export const getSimulatedPlayerFromView = (
 export const getClosestMob = (
     { dimension, location }: HasDimensionLocation,
     maxDistance: number,
-    options = {}
+    options: Options = {}
 ): Entity | undefined => {
     return dimension.getEntities({
         excludeTypes: [
@@ -40,7 +40,7 @@ export const getClosestMob = (
 export const getClosestPlayer = (
     { dimension, location }: HasDimensionLocation,
     maxDistance: number,
-    options: EntityQueryOptions = {}
+    options: Options = {}
 ): Player | undefined => {
     return dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
@@ -55,3 +55,5 @@ interface HasDimensionLocation {
     dimension: Dimension;
     location: Vector3;
 }
+
+type Options = Omit<EntityQueryOptions, 'location' | 'maxDistance' | 'closest'>;

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -9,10 +9,10 @@ import type {
 import type { SimulatedPlayer } from '@minecraft/server-gametest';
 
 export const getSimulatedPlayerFromView = (
-    e: Entity,
+    entity: Entity,
     maxDistance = 16
 ): SimulatedPlayer | undefined => {
-    return e.getEntitiesFromViewDirection({
+    return entity.getEntitiesFromViewDirection({
         maxDistance,
         tags: [SIGN.YUME_SIM_SIGN],
     })[0]?.entity as SimulatedPlayer | undefined;

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,12 +1,12 @@
 import { SIGN } from '@/constants';
-import type { Block, Dimension, Entity, EntityQueryOptions, Player, Vector3 } from '@minecraft/server';
+import type { Dimension, Entity, EntityQueryOptions, Player, Vector3 } from '@minecraft/server';
 import type { SimulatedPlayer } from '@minecraft/server-gametest';
 
 export const getSimulatedPlayerFromView = (e: Entity, maxDistance = 16): SimulatedPlayer => {
     return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
 };
 
-export const getClosestMob = (location: Vector3, dimension: Dimension, maxDistance: number, Options = {}): Entity => {
+export const getClosestMob = ({ dimension, location }: HasDimensionLocation, maxDistance: number, Options = {}): Entity => {
     return dimension.getEntities({
         excludeTypes: ["minecraft:player", "minecraft:arrow", "minecraft:xp_orb", "minecraft:item"],
         closest: 1,
@@ -16,12 +16,17 @@ export const getClosestMob = (location: Vector3, dimension: Dimension, maxDistan
     })[0];
 };
 
-export const getClosestPlayer = (who: Entity | Block, maxDistance: number, defEntityQueryOptions: EntityQueryOptions = {}): Player => {
-    return who.dimension.getPlayers({
+export const getClosestPlayer = ({ dimension, location }: HasDimensionLocation, maxDistance: number, defEntityQueryOptions: EntityQueryOptions = {}): Player => {
+    return dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,
-        location: who.location,
+        location,
         maxDistance,
         ...defEntityQueryOptions,
     })[0];
 };
+
+interface HasDimensionLocation {
+    dimension: Dimension;
+    location: Vector3;
+}

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -8,24 +8,20 @@ export function getSimulatedPlayerFromView(e: Entity, maxDistance = 16): Simulat
 }
 
 export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance:number, Options={}){
-    const EntityQueryOption:EntityQueryOptions = {}
-    EntityQueryOption.maxDistance = maxDistance
-    EntityQueryOption.location    = location
-    EntityQueryOption.excludeTypes= ["minecraft:player","minecraft:arrow","minecraft:xp_orb","minecraft:item"]
-    EntityQueryOption.closest   = 1
-    Object.assign(EntityQueryOption,Options)
-    return dimension.getEntities(EntityQueryOption)
+    return dimension.getEntities({
+        excludeTypes: ["minecraft:player", "minecraft:arrow", "minecraft:xp_orb", "minecraft:item"],
+        closest: 1,
+        location,
+        maxDistance,
+        ...Options,
+    });
 }
 export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions):Player[] {
-    const EQO: EntityQueryOptions = {}
-    EQO.maxDistance = maxDistance
-    EQO.location    = who.location
-    // EQO.excludeTypes= ["minecraft:arrow","minecraft:xp_orb","minecraft:item"]
-    EQO.closest   = 1
-    EQO.excludeTags = [SIGN.YUME_SIM_SIGN]
-    Object.assign(EQO,defEntityQueryOptions)
-    const entities = who.dimension.getPlayers(EQO)
-    const targets:Player[] = []
-    for(const entity of entities)targets.push(entity)
-    return targets
+    return who.dimension.getPlayers({
+        excludeTags: [SIGN.YUME_SIM_SIGN],
+        closest: 1,
+        location: who.location,
+        maxDistance,
+        ...defEntityQueryOptions,
+    });
 }

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -16,7 +16,7 @@ export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance
         ...Options,
     });
 }
-export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions):Player[] {
+export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions={}):Player[] {
     return who.dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -11,18 +11,18 @@ import type { SimulatedPlayer } from '@minecraft/server-gametest';
 export const getSimulatedPlayerFromView = (
     e: Entity,
     maxDistance = 16
-): SimulatedPlayer => {
+): SimulatedPlayer | undefined => {
     return e.getEntitiesFromViewDirection({
         maxDistance,
         tags: [SIGN.YUME_SIM_SIGN],
-    })[0]?.entity as SimulatedPlayer;
+    })[0]?.entity as SimulatedPlayer | undefined;
 };
 
 export const getClosestMob = (
     { dimension, location }: HasDimensionLocation,
     maxDistance: number,
     Options = {}
-): Entity => {
+): Entity | undefined => {
     return dimension.getEntities({
         excludeTypes: [
             'minecraft:player',
@@ -41,7 +41,7 @@ export const getClosestPlayer = (
     { dimension, location }: HasDimensionLocation,
     maxDistance: number,
     defEntityQueryOptions: EntityQueryOptions = {}
-): Player => {
+): Player | undefined => {
     return dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -14,14 +14,14 @@ export function getClosestMob(location:Vector3, dimension:Dimension, maxDistance
         location,
         maxDistance,
         ...Options,
-    });
+    })[0];
 }
-export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions={}):Player[] {
+export function getClosestPlayer(who:Entity|Block, maxDistance:number, defEntityQueryOptions:EntityQueryOptions={}):Player {
     return who.dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,
         location: who.location,
         maxDistance,
         ...defEntityQueryOptions,
-    });
+    })[0];
 }

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -4,7 +4,7 @@ import { SIGN } from '@/constants'
 
 
 export function getSimulatedPlayerFromView(e: Entity, maxDistance = 16): SimulatedPlayer {
-    return (<SimulatedPlayer>e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity);
+    return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
 }
 
 export function getEntitiesNear(location:Vector3, dimension:Dimension, maxDistance:number, Options={}){

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,14 +1,35 @@
 import { SIGN } from '@/constants';
-import type { Dimension, Entity, EntityQueryOptions, Player, Vector3 } from '@minecraft/server';
+import type {
+    Dimension,
+    Entity,
+    EntityQueryOptions,
+    Player,
+    Vector3,
+} from '@minecraft/server';
 import type { SimulatedPlayer } from '@minecraft/server-gametest';
 
-export const getSimulatedPlayerFromView = (e: Entity, maxDistance = 16): SimulatedPlayer => {
-    return e.getEntitiesFromViewDirection({ maxDistance, tags: [SIGN.YUME_SIM_SIGN] })[0]?.entity as SimulatedPlayer;
+export const getSimulatedPlayerFromView = (
+    e: Entity,
+    maxDistance = 16
+): SimulatedPlayer => {
+    return e.getEntitiesFromViewDirection({
+        maxDistance,
+        tags: [SIGN.YUME_SIM_SIGN],
+    })[0]?.entity as SimulatedPlayer;
 };
 
-export const getClosestMob = ({ dimension, location }: HasDimensionLocation, maxDistance: number, Options = {}): Entity => {
+export const getClosestMob = (
+    { dimension, location }: HasDimensionLocation,
+    maxDistance: number,
+    Options = {}
+): Entity => {
     return dimension.getEntities({
-        excludeTypes: ["minecraft:player", "minecraft:arrow", "minecraft:xp_orb", "minecraft:item"],
+        excludeTypes: [
+            'minecraft:player',
+            'minecraft:arrow',
+            'minecraft:xp_orb',
+            'minecraft:item',
+        ],
         closest: 1,
         location,
         maxDistance,
@@ -16,7 +37,11 @@ export const getClosestMob = ({ dimension, location }: HasDimensionLocation, max
     })[0];
 };
 
-export const getClosestPlayer = ({ dimension, location }: HasDimensionLocation, maxDistance: number, defEntityQueryOptions: EntityQueryOptions = {}): Player => {
+export const getClosestPlayer = (
+    { dimension, location }: HasDimensionLocation,
+    maxDistance: number,
+    defEntityQueryOptions: EntityQueryOptions = {}
+): Player => {
     return dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -21,7 +21,7 @@ export const getSimulatedPlayerFromView = (
 export const getClosestMob = (
     { dimension, location }: HasDimensionLocation,
     maxDistance: number,
-    Options = {}
+    options = {}
 ): Entity | undefined => {
     return dimension.getEntities({
         excludeTypes: [
@@ -33,21 +33,21 @@ export const getClosestMob = (
         closest: 1,
         location,
         maxDistance,
-        ...Options,
+        ...options,
     })[0];
 };
 
 export const getClosestPlayer = (
     { dimension, location }: HasDimensionLocation,
     maxDistance: number,
-    defEntityQueryOptions: EntityQueryOptions = {}
+    options: EntityQueryOptions = {}
 ): Player | undefined => {
     return dimension.getPlayers({
         excludeTags: [SIGN.YUME_SIM_SIGN],
         closest: 1,
         location,
         maxDistance,
-        ...defEntityQueryOptions,
+        ...options,
     })[0];
 };
 

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -6,7 +6,7 @@ import { SIGN } from '@/constants'
 // getEntitiesFromViewDirection
 export const getSimPlayer = {
     // only one
-    fromView: (e:Entity,maxDistance=16):SimulatedPlayer=>(<SimulatedPlayer>e.getEntitiesFromViewDirection({maxDistance}).find(({entity}) => entity.hasTag(SIGN.YUME_SIM_SIGN))?.entity),
+    fromView: (e:Entity,maxDistance=16):SimulatedPlayer=>(<SimulatedPlayer>e.getEntitiesFromViewDirection({maxDistance, tags: [SIGN.YUME_SIM_SIGN]})[0]?.entity),
 
 }
 


### PR DESCRIPTION
- 使用箭头函数统一函数声明方式
- 严格函数返回类型（增加 `undefined` 声明）
- 简化函数实现并直接使用标签过滤
- 优化代码格式与导入顺序
- 引入 `HasDimensionLocation `接口统一参数结构
- 统一 `options` 参数命名和类型约束
- 为 `getClosestMob` 和 `getClosestPlayer` 添加默认 `maxDistance = 16`
- 函数重命名为更语义化的 `getClosestMob`/`getClosestPlayer`
- 调整12个文件适配新函数结构

BREAKING CHANGE: 
- 函数名更改
- `getClosestMob`/`getClosestPlayer `的第一个参数改为对象
- 返回类型调整为对象而非数组